### PR TITLE
Fix a small logic bug

### DIFF
--- a/src/components/WithdrawPage.tsx
+++ b/src/components/WithdrawPage.tsx
@@ -96,7 +96,7 @@ const WithdrawPage = (props: Props): ReactElement => {
   return (
     <div className="withdraw">
       <TopMenu activeTab={"withdraw"} />
-      {myShareData ? (
+      {!myShareData ? (
         <NoShareContent />
       ) : (
         <div className="content">


### PR DESCRIPTION
Fix the bug that changed the withdraw content display to the wrong logic in order to test the display when resolving a merge conflict. 