### PR TITLE
Set homepage to . in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "storybook": "start-storybook -p 6006 -s public --no-dll",
     "build-storybook": "build-storybook -s public --no-dll"
   },
+  "homepage": ".",
   "husky": {
     "hooks": {
       "pre-commit": "npm run lint:fix"


### PR DESCRIPTION
This is to fix the following errors when the site is accessed via IPFS gateways and not the fleek domain:

![Screen Shot 2021-01-05 at 6 39 24 PM](https://user-images.githubusercontent.com/972382/103722696-5ded2780-4f85-11eb-9ac3-5740d696b1b0.png)

_NB_
https://www.reddit.com/r/ipfs/comments/8k3f8m/react_app_build_not_working_when_published_to_ipfs/
https://create-react-app.dev/docs/deployment/#serving-the-same-build-from-different-paths