### PR TITLE
Adjust space of advanced options table on Swap page

### DIFF
--- a/src/components/SwapPage.scss
+++ b/src/components/SwapPage.scss
@@ -97,15 +97,16 @@ div.swapPage {
     }
 
     .table {
-      width: calc(100% - 24px);
+      width: calc(100% - 48px);
       background: var(--background-element);
       margin-top: 16px;
       border: 1px solid var(--outline);
       border-radius: 10px;
-      padding: 16px 12px;
+      padding: 16px 24px;
 
       display: flex;
       flex-direction: row-reverse;
+      justify-content: space-between;
 
       input {
         width: 42px;
@@ -113,6 +114,7 @@ div.swapPage {
         border-radius: 0;
         height: 20px;
         font-size: 80%;
+        outline: 1px solid $black;
       }
 
       input:focus {
@@ -125,16 +127,8 @@ div.swapPage {
         letter-spacing: -0.04em;
       }
 
-      .tableOption {
-        margin-left: 32px;
-
-        &:last-child {
-          margin-left: 0;
-        }
-
-        .options {
-          margin-top: 8px;
-        }
+      .tableOption .options {
+        margin-top: 10px;
       }
     }
 
@@ -236,10 +230,11 @@ div.swapPage {
       font-weight: $normal;
       color: var(--text);
       letter-spacing: -0.04em;
-      padding: 0 12px 0 0;
+      padding: 0 16px 0 0;
 
       &:hover {
         transform: none;
+        font-weight: $bold;
       }
 
       &:focus {

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -174,7 +174,7 @@ const SwapPage = (props: Props): ReactElement => {
                   </button>
                 </div>
               </div>
-              <div className="maxSlippage tableOption">
+              <div className="tableOption">
                 <span className="label">{t("maxSlippage")}</span>
                 <div className="options">
                   <button
@@ -195,7 +195,7 @@ const SwapPage = (props: Props): ReactElement => {
                   <span style={{ marginLeft: "4px" }}>%</span>
                 </div>
               </div>
-              <div className="maxSlippage tableOption">
+              <div className="tableOption">
                 <span className="label">{t("gas")}</span>
                 <div className="options">
                   <button
@@ -245,7 +245,6 @@ const SwapPage = (props: Props): ReactElement => {
                   ></input>
                 </div>
               </div>
-              {/* TODO: fix spacing */}
             </div>
           </div>
         </div>


### PR DESCRIPTION
* Fix the space of advanced options table on Swap page. 

![Screen Shot 2021-01-06 at 11 34 34 PM](https://user-images.githubusercontent.com/11672986/103851906-ce28a580-5078-11eb-945f-f725787dfcec.png)

Close #208 