### PR TITLE
Add additional GA4 custom event tracking

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -5,11 +5,11 @@ import { UnsupportedChainIdError, useWeb3React } from "@web3-react/core"
 import { injected, walletconnect, walletlink } from "../connectors"
 
 import coinbasewalletIcon from "../assets/icons/coinbasewallet.svg"
+import { logEvent } from "../utils/googleAnalytics"
 import metamaskIcon from "../assets/icons/metamask.svg"
 import { useTranslation } from "react-i18next"
 import walletconnectIcon from "../assets/icons/walletconnect.svg"
 
-// Dumb data starts
 const wallets = [
   {
     name: "MetaMask",
@@ -31,7 +31,7 @@ const wallets = [
 interface Props {
   onClose: () => void
 }
-// Dumb data ends
+
 function ConnectWallet({ onClose }: Props): ReactElement {
   const { t } = useTranslation()
   const { activate } = useWeb3React()
@@ -51,6 +51,7 @@ function ConnectWallet({ onClose }: Props): ReactElement {
                   // TODO: handle error
                 }
               })
+              logEvent("change_wallet", { name: wallet.name })
               onClose()
             }}
           >

--- a/src/components/DepositPage.tsx
+++ b/src/components/DepositPage.tsx
@@ -27,6 +27,7 @@ import TokenInput from "./TokenInput"
 import TopMenu from "./TopMenu"
 import classNames from "classnames"
 import { formatUnits } from "@ethersproject/units"
+import { logEvent } from "../utils/googleAnalytics"
 import { useTranslation } from "react-i18next"
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
@@ -299,6 +300,10 @@ const DepositPage = (props: Props): ReactElement => {
               onConfirm={(): void => {
                 setPopUp("confirm")
                 onConfirmTransaction?.().finally(() => setModalOpen(false))
+                logEvent(
+                  "deposit",
+                  (poolData && { pool: poolData?.name }) || {},
+                )
               }}
               onClose={(): void => setModalOpen(false)}
             />

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -14,6 +14,7 @@ import ReviewSwap from "./ReviewSwap"
 import SwapForm from "./SwapForm"
 import TopMenu from "./TopMenu"
 import classNames from "classnames"
+import { logEvent } from "../utils/googleAnalytics"
 import { updateSwapAdvancedMode } from "../state/user"
 import { useTranslation } from "react-i18next"
 
@@ -270,6 +271,10 @@ const SwapPage = (props: Props): ReactElement => {
               onConfirm={async (): Promise<void> => {
                 setPopUp("confirm")
                 await onConfirmTransaction()
+                logEvent("swap", {
+                  from: fromState.symbol,
+                  to: toState.symbol,
+                })
                 setModalOpen(false)
               }}
               data={{

--- a/src/components/WithdrawPage.tsx
+++ b/src/components/WithdrawPage.tsx
@@ -24,6 +24,7 @@ import TokenInput from "./TokenInput"
 import TopMenu from "./TopMenu"
 import { WithdrawFormState } from "../hooks/useWithdrawFormState"
 import classNames from "classnames"
+import { logEvent } from "../utils/googleAnalytics"
 import { useTranslation } from "react-i18next"
 
 export interface ReviewWithdrawData {
@@ -328,6 +329,10 @@ const WithdrawPage = (props: Props): ReactElement => {
                 onConfirm={(): void => {
                   onConfirmTransaction()
                   setPopUp("confirm")
+                  logEvent(
+                    "withdraw",
+                    (poolData && { pool: poolData?.name }) || {},
+                  )
                 }}
                 onClose={(): void => setModalOpen(false)}
               />

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -11,5 +11,6 @@ interface Window {
     on?: (...args: any[]) => void
     removeListener?: (...args: any[]) => void
   }
+  gtag?: (...args: any[]) => void
   web3?: {}
 }

--- a/src/utils/googleAnalytics.ts
+++ b/src/utils/googleAnalytics.ts
@@ -1,0 +1,8 @@
+export function logEvent(name: string, params: Record<string, string>): void {
+  // gtag is only loaded in index.html when NODE_ENV is set to production, so check if it's a function
+  if (typeof window.gtag === "function") {
+    window.gtag("event", name, params)
+  } else {
+    console.debug(`Logging event '${name}' with parameters: `, params)
+  }
+}


### PR DESCRIPTION
This adds the following custom events and their associated parameters:
- `change_wallet`
  - `name` - name of the wallet provider
- `swap`
  - `from` - from ticker symbol
  - `to` - to ticker symbol
- `deposit`
   - `pool` - pool name
- `withdraw`
  - `pool` - pool name

Closes #216