### PR TITLE
Fix Slippage % Display

### DIFF
--- a/src/components/DepositPage.tsx
+++ b/src/components/DepositPage.tsx
@@ -160,7 +160,7 @@ const DepositPage = (props: Props): ReactElement => {
                   >
                     {" "}
                     {parseFloat(
-                      formatUnits(transactionInfoData.bonus, 18),
+                      formatUnits(transactionInfoData.bonus, 18 - 2),
                     ).toFixed(4)}
                     %
                   </span>

--- a/src/components/WithdrawPage.tsx
+++ b/src/components/WithdrawPage.tsx
@@ -181,7 +181,9 @@ const WithdrawPage = (props: Props): ReactElement => {
                       }
                     >
                       {" "}
-                      {parseFloat(formatUnits(reviewData.bonus, 18)).toFixed(4)}
+                      {parseFloat(
+                        formatUnits(reviewData.bonus, 18 - 2),
+                      ).toFixed(4)}
                       %
                     </span>
                   </div>


### PR DESCRIPTION
Previous formatting didn't shift decimals when formatting as percentage. 