### PR TITLE
Check pending deposit against pool cap as well as user cap

### DIFF
--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -32,6 +32,7 @@ export interface PoolDataType {
   poolAccountLimit: BigNumber
   isAcceptingDeposits: boolean
   keepApr: BigNumber
+  poolLPTokenCap: BigNumber
 }
 
 export interface UserShareType {
@@ -111,7 +112,14 @@ export default function usePoolData(
         allowlist.getPoolCap(swapContract.address),
         allowlist.isAccountVerified(account),
       ])
-      const isAcceptingDeposits = poolLPTokenCap.gt(totalLpTokenBalance)
+      // Since we will never exactly hit the cap, subtract 0.5btc for some wiggle room
+      const isAcceptingDeposits = poolLPTokenCap
+        .sub(
+          BigNumber.from(10)
+            .pow(18 - 1)
+            .mul(5),
+        )
+        .gt(totalLpTokenBalance)
 
       const virtualPrice = totalLpTokenBalance.isZero()
         ? BigNumber.from(10).pow(18)
@@ -216,6 +224,7 @@ export default function usePoolData(
         utilization: "XXX", // TODO
         apy: "XXX", // TODO
         poolAccountLimit,
+        poolLPTokenCap,
         isAcceptingDeposits,
         keepApr,
       }

--- a/src/pages/DepositBTC.tsx
+++ b/src/pages/DepositBTC.tsx
@@ -75,12 +75,16 @@ function DepositBTC(): ReactElement | null {
       }
       setEstDepositLPTokenAmount(depositLPTokenAmount)
 
+      // check if the new deposit will violate either the user cap or pool cap
       const futureUserLPTokenBalance = depositLPTokenAmount.add(
-        userShareData?.lpTokenBalance,
+        userShareData?.lpTokenBalance || BigNumber.from("0"),
       )
-      const exceedsMaxDeposits = futureUserLPTokenBalance.gt(
-        poolData.poolAccountLimit,
+      const futurePoolLPTokenBalance = depositLPTokenAmount.add(
+        poolData.totalLocked,
       )
+      const exceedsMaxDeposits =
+        futureUserLPTokenBalance.gt(poolData.poolAccountLimit) ||
+        futurePoolLPTokenBalance.gt(poolData.poolLPTokenCap)
       if (willExceedMaxDeposits !== exceedsMaxDeposits) {
         setWillExceedMaxDeposit(exceedsMaxDeposits)
       }


### PR DESCRIPTION
Currently we check: 1) if pool cap is already met exactly 2) if pending deposit will exceed user cap.
This PR adds some wiggle room to the pool cap check since it will never be met *exactly*, and also checks pending deposits against the pool cap.