### PR TITLE
Change price impact threshold to 1%

### DIFF
--- a/src/utils/__tests__/priceImpact.ts
+++ b/src/utils/__tests__/priceImpact.ts
@@ -36,23 +36,19 @@ describe("calculatePriceImpact", () => {
 })
 
 describe("isHighPriceImpact", () => {
-  it("returns true for impact >= 10%", () => {
-    const negTenPct = BigNumber.from(10)
+  it("returns true for impact >= 1%", () => {
+    const negOnePct = BigNumber.from(10)
       .pow(18 - 2)
-      .mul(-10)
-    const negElevenPct = BigNumber.from(10)
+      .mul(-1)
+    const negTwoPct = BigNumber.from(10)
       .pow(18 - 2)
-      .mul(-11)
-    expect(isHighPriceImpact(negTenPct)).toBe(true)
-    expect(isHighPriceImpact(negElevenPct)).toBe(true)
+      .mul(-2)
+    expect(isHighPriceImpact(negOnePct)).toBe(true)
+    expect(isHighPriceImpact(negTwoPct)).toBe(true)
   })
 
-  it("returns false for impact < 10%", () => {
-    const negNinePct = BigNumber.from(10)
-      .pow(18 - 2)
-      .mul(-9)
+  it("returns false for impact < 1%", () => {
     const posOnePct = BigNumber.from(10).pow(18 - 2)
-    expect(isHighPriceImpact(negNinePct)).toBe(false)
     expect(isHighPriceImpact(posOnePct)).toBe(false)
     expect(isHighPriceImpact(BigNumber.from(0))).toBe(false)
   })

--- a/src/utils/priceImpact.ts
+++ b/src/utils/priceImpact.ts
@@ -1,8 +1,11 @@
 import { BigNumber } from "@ethersproject/bignumber"
 
 export function isHighPriceImpact(priceImpact: BigNumber): boolean {
-  const negOneTenth = BigNumber.from(-10).pow(18 - 1)
-  return priceImpact.lte(negOneTenth)
+  // assumes that priceImpact has 18d precision
+  const negOne = BigNumber.from(10)
+    .pow(18 - 2)
+    .mul(-1)
+  return priceImpact.lte(negOne)
 }
 
 export function calculatePriceImpact(


### PR DESCRIPTION
Per a conversation with @alphastorm , lower the threshold for a priceimpact warning from 10% -> 1%