### PR TITLE
Correct deadline loading logic

### DIFF
--- a/src/components/DeadlineField.tsx
+++ b/src/components/DeadlineField.tsx
@@ -55,13 +55,6 @@ export default function DeadlineField(): ReactElement {
           onClick={(): PayloadAction<Deadlines> =>
             dispatch(updateTransactionDeadlineSelected(Deadlines.Custom))
           }
-          // onChange={(e): void => {
-          //   const deadlineNumber =
-          //     e.target.value === "" || parseFloat(e.target.value) <= 0
-          //       ? Deadlines.Ten // if left blank, deadline defaults to 10
-          //       : parseFloat(e.target.value)
-          //   dispatch(updateTransactionDeadline(deadlineNumber))
-          // }}
           value={transactionDeadlineCustom}
           onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {
             const value = e.target.value

--- a/src/components/DeadlineField.tsx
+++ b/src/components/DeadlineField.tsx
@@ -1,42 +1,47 @@
 import "./DeadlineField.scss"
 
 import React, { ReactElement } from "react"
+import {
+  updateTransactionDeadlineCustom,
+  updateTransactionDeadlineSelected,
+} from "../state/user"
 import { useDispatch, useSelector } from "react-redux"
 
 import { AppDispatch } from "../state"
 import { AppState } from "../state/index"
 import { Deadlines } from "../state/user"
 import { PayloadAction } from "@reduxjs/toolkit"
-
 import classNames from "classnames"
-import { updateTransactionDeadline } from "../state/user"
 import { useTranslation } from "react-i18next"
 
 export default function DeadlineField(): ReactElement {
   const { t } = useTranslation()
   const dispatch = useDispatch<AppDispatch>()
 
-  const { transactionDeadline } = useSelector((state: AppState) => state.user)
+  const {
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
+  } = useSelector((state: AppState) => state.user)
   return (
     <div className="deadlineField">
       <div className="options">
         <div className="label">{t("deadline")}: </div>
         <button
           className={classNames({
-            selected: transactionDeadline === Deadlines.Ten,
+            selected: transactionDeadlineSelected === Deadlines.Ten,
           })}
           onClick={(): void => {
-            dispatch(updateTransactionDeadline(Deadlines.Ten))
+            dispatch(updateTransactionDeadlineSelected(Deadlines.Ten))
           }}
         >
           <span>10 {t("minutes")}</span>
         </button>
         <button
           className={classNames({
-            selected: transactionDeadline === Deadlines.Thirty,
+            selected: transactionDeadlineSelected === Deadlines.Thirty,
           })}
           onClick={(): void => {
-            dispatch(updateTransactionDeadline(Deadlines.Thirty))
+            dispatch(updateTransactionDeadlineSelected(Deadlines.Thirty))
           }}
         >
           <span>30 {t("minutes")}</span>
@@ -44,21 +49,33 @@ export default function DeadlineField(): ReactElement {
         <input
           type="text"
           className={classNames({
-            selected: transactionDeadline === Deadlines.Custom,
+            selected: transactionDeadlineSelected === Deadlines.Custom,
           })}
           placeholder="10"
           onClick={(): PayloadAction<Deadlines> =>
-            dispatch(updateTransactionDeadline(Deadlines.Custom))
+            dispatch(updateTransactionDeadlineSelected(Deadlines.Custom))
           }
-          onChange={(e): void => {
-            const deadlineNumber =
-              e.target.value === "" || parseFloat(e.target.value) <= 0
-                ? Deadlines.Ten // if left blank, deadline defaults to 10
-                : parseFloat(e.target.value)
-            dispatch(updateTransactionDeadline(deadlineNumber))
+          // onChange={(e): void => {
+          //   const deadlineNumber =
+          //     e.target.value === "" || parseFloat(e.target.value) <= 0
+          //       ? Deadlines.Ten // if left blank, deadline defaults to 10
+          //       : parseFloat(e.target.value)
+          //   dispatch(updateTransactionDeadline(deadlineNumber))
+          // }}
+          value={transactionDeadlineCustom}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {
+            const value = e.target.value
+            if (value && !isNaN(+value)) {
+              dispatch(updateTransactionDeadlineCustom(value))
+              if (transactionDeadlineSelected !== Deadlines.Custom) {
+                dispatch(updateTransactionDeadlineSelected(Deadlines.Custom))
+              }
+            } else {
+              dispatch(updateTransactionDeadlineSelected(Deadlines.Ten))
+            }
           }}
         />
-        <span> {t("minutes")}</span>
+        &nbsp;{t("minutes")}
       </div>
     </div>
   )

--- a/src/components/DepositPage.tsx
+++ b/src/components/DepositPage.tsx
@@ -32,7 +32,6 @@ import { useTranslation } from "react-i18next"
 /* eslint-disable @typescript-eslint/no-explicit-any */
 interface Props {
   title: string
-  infiniteApproval: boolean
   onConfirmTransaction: () => Promise<void>
   onChangeTokenInputValue: (tokenSymbol: string, value: string) => void
   tokens: Array<{

--- a/src/components/GasField.tsx
+++ b/src/components/GasField.tsx
@@ -63,14 +63,17 @@ export default function GasField(): ReactElement {
             selected: gasPriceSelected === GasPrices.Custom,
           })}
           value={gasCustom?.valueRaw}
-          onClick={(): PayloadAction<GasPrices> =>
-            dispatch(updateGasPriceSelected(GasPrices.Custom))
-          }
-          onChange={(
-            e: React.ChangeEvent<HTMLInputElement>,
-          ): PayloadAction<string> =>
-            dispatch(updateGasPriceCustom(e.target.value))
-          }
+          onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {
+            const value = e.target.value
+            if (value && !isNaN(+value)) {
+              dispatch(updateGasPriceCustom(value))
+              if (gasPriceSelected !== GasPrices.Custom) {
+                dispatch(updateGasPriceSelected(GasPrices.Custom))
+              }
+            } else {
+              dispatch(updateGasPriceSelected(GasPrices.Fast))
+            }
+          }}
         />
       </div>
     </div>

--- a/src/components/ReviewDeposit.tsx
+++ b/src/components/ReviewDeposit.tsx
@@ -1,7 +1,11 @@
 import "./ReviewDeposit.scss"
 
 import React, { ReactElement, useState } from "react"
-import { formatBNToPercentString, formatBNToString } from "../utils"
+import {
+  formatBNToPercentString,
+  formatBNToString,
+  formatDeadlineToNumber,
+} from "../utils"
 
 import { AppState } from "../state/index"
 import Button from "./Button"
@@ -31,7 +35,8 @@ function ReviewDeposit({
     slippageSelected,
     gasPriceSelected,
     gasCustom,
-    transactionDeadline,
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
   } = useSelector((state: AppState) => state.user)
   const { gasStandard, gasFast, gasInstant } = useSelector(
     (state: AppState) => state.application,
@@ -41,7 +46,10 @@ function ReviewDeposit({
     setHasConfirmedHighPriceImpact,
   ] = useState(false)
   const isHighPriceImpactTxn = isHighPriceImpact(transactionData.priceImpact)
-
+  const deadline = formatDeadlineToNumber(
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
+  )
   return (
     <div className="reviewDeposit">
       <h3>{t("reviewDeposit")}</h3>
@@ -121,7 +129,7 @@ function ReviewDeposit({
         <div className="depositInfoItem">
           <span className="label">{t("deadline")}</span>
           <span className="value">
-            {transactionDeadline} {t("minutes")}
+            {deadline} {t("minutes")}
           </span>
         </div>
         <div className="depositInfoItem">

--- a/src/components/ReviewSwap.tsx
+++ b/src/components/ReviewSwap.tsx
@@ -1,13 +1,13 @@
 import "./ReviewSwap.scss"
 
 import React, { ReactElement, useState } from "react"
+import { formatBNToString, formatDeadlineToNumber } from "../utils"
 
 import { AppState } from "../state/index"
 import { BigNumber } from "@ethersproject/bignumber"
 import Button from "./Button"
 import HighPriceImpactConfirmation from "./HighPriceImpactConfirmation"
 import { TOKENS_MAP } from "../constants"
-import { formatBNToString } from "../utils"
 import { formatGasToString } from "../utils/gas"
 import { formatSlippageToString } from "../utils/slippage"
 import iconDown from "../assets/icons/icon_down.svg"
@@ -36,7 +36,8 @@ function ReviewSwap({ onClose, onConfirm, data }: Props): ReactElement {
     slippageSelected,
     gasPriceSelected,
     gasCustom,
-    transactionDeadline,
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
   } = useSelector((state: AppState) => state.user)
   const { gasStandard, gasFast, gasInstant } = useSelector(
     (state: AppState) => state.application,
@@ -49,6 +50,10 @@ function ReviewSwap({ onClose, onConfirm, data }: Props): ReactElement {
   const toToken = TOKENS_MAP[data.to.symbol]
   const isHighPriceImpactTxn = isHighPriceImpact(
     data.exchangeRateInfo.priceImpact,
+  )
+  const deadline = formatDeadlineToNumber(
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
   )
 
   return (
@@ -117,7 +122,7 @@ function ReviewSwap({ onClose, onConfirm, data }: Props): ReactElement {
           <div className="row">
             <span className="title">{t("deadline")}</span>
             <span className="value floatRight">
-              {transactionDeadline} {t("minutes")}
+              {deadline} {t("minutes")}
             </span>
           </div>
           {isHighPriceImpactTxn && (

--- a/src/components/ReviewWithdraw.tsx
+++ b/src/components/ReviewWithdraw.tsx
@@ -7,6 +7,7 @@ import Button from "./Button"
 import { GasPrices } from "../state/user"
 import HighPriceImpactConfirmation from "./HighPriceImpactConfirmation"
 import { ReviewWithdrawData } from "./WithdrawPage"
+import { formatDeadlineToNumber } from "../utils"
 import { formatGasToString } from "../utils/gas"
 import { formatSlippageToString } from "../utils/slippage"
 import { isHighPriceImpact } from "../utils/priceImpact"
@@ -27,7 +28,8 @@ function ReviewWithdraw({ onClose, onConfirm, data }: Props): ReactElement {
     slippageSelected,
     gasPriceSelected,
     gasCustom,
-    transactionDeadline,
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
   } = useSelector((state: AppState) => state.user)
   const { gasStandard, gasFast, gasInstant } = useSelector(
     (state: AppState) => state.application,
@@ -37,7 +39,10 @@ function ReviewWithdraw({ onClose, onConfirm, data }: Props): ReactElement {
     setHasConfirmedHighPriceImpact,
   ] = useState(false)
   const isHighSlippageTxn = isHighPriceImpact(data.priceImpact)
-
+  const deadline = formatDeadlineToNumber(
+    transactionDeadlineSelected,
+    transactionDeadlineCustom,
+  )
   return (
     <div className="reviewWithdraw">
       <h3>{t("youWillReceive")}</h3>
@@ -76,7 +81,7 @@ function ReviewWithdraw({ onClose, onConfirm, data }: Props): ReactElement {
         <div className="withdrawInfoItem">
           <span className="label">{t("deadline")}</span>
           <span className="value">
-            {transactionDeadline} {t("minutes")}
+            {deadline} {t("minutes")}
           </span>
         </div>
         <div className="withdrawInfoItem">

--- a/src/components/SlippageField.tsx
+++ b/src/components/SlippageField.tsx
@@ -46,12 +46,17 @@ export default function SlippageField(): ReactElement {
         </button>
         <input
           value={slippageCustom?.valueRaw}
-          onClick={(): PayloadAction<Slippages> =>
-            dispatch(updateSlippageSelected(Slippages.Custom))
-          }
-          onChange={(e): PayloadAction<string> =>
-            dispatch(updateSlippageCustom(e.target.value))
-          }
+          onChange={(e: React.ChangeEvent<HTMLInputElement>): void => {
+            const value = e.target.value
+            if (value && !isNaN(+value)) {
+              dispatch(updateSlippageCustom(value))
+              if (slippageSelected !== Slippages.Custom) {
+                dispatch(updateSlippageSelected(Slippages.Custom))
+              }
+            } else {
+              dispatch(updateSlippageSelected(Slippages.OneTenth))
+            }
+          }}
         />
         &nbsp;%
       </div>

--- a/src/pages/DepositBTC.tsx
+++ b/src/pages/DepositBTC.tsx
@@ -34,14 +34,6 @@ function DepositBTC(): ReactElement | null {
   const [tokenFormState, updateTokenFormState] = useTokenFormState(
     BTC_POOL_TOKENS,
   )
-  const {
-    slippageCustom,
-    slippageSelected,
-    gasPriceSelected,
-    gasCustom,
-    infiniteApproval,
-    transactionDeadline,
-  } = useSelector((state: AppState) => state.user)
   const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
   const [estDepositLPTokenAmount, setEstDepositLPTokenAmount] = useState(Zero)
   const [priceImpact, setPriceImpact] = useState(Zero)
@@ -112,15 +104,7 @@ function DepositBTC(): ReactElement | null {
   })
 
   async function onConfirmTransaction(): Promise<void> {
-    await approveAndDeposit({
-      slippageCustom,
-      slippageSelected,
-      infiniteApproval,
-      tokenFormState,
-      gasPriceSelected,
-      gasCustom,
-      transactionDeadline,
-    })
+    await approveAndDeposit(tokenFormState)
     // Clear input after deposit
     updateTokenFormState(
       BTC_POOL_TOKENS.reduce(
@@ -154,7 +138,6 @@ function DepositBTC(): ReactElement | null {
       historicalPoolData={null}
       myShareData={userShareData}
       transactionData={depositTransaction}
-      infiniteApproval={infiniteApproval}
     />
   )
 }

--- a/src/pages/SwapBTC.tsx
+++ b/src/pages/SwapBTC.tsx
@@ -2,7 +2,6 @@ import { BTC_POOL_NAME, BTC_POOL_TOKENS, TOKENS_MAP } from "../constants"
 import React, { ReactElement, useCallback, useState } from "react"
 import { formatUnits, parseUnits } from "@ethersproject/units"
 
-import { AppState } from "../state"
 import { BigNumber } from "@ethersproject/bignumber"
 import SwapPage from "../components/SwapPage"
 import { calculateExchangeRate } from "../utils"
@@ -11,7 +10,6 @@ import { debounce } from "lodash"
 import { useApproveAndSwap } from "../hooks/useApproveAndSwap"
 import usePoolData from "../hooks/usePoolData"
 import { usePoolTokenBalances } from "../state/wallet/hooks"
-import { useSelector } from "react-redux"
 import { useSwapContract } from "../hooks/useContract"
 import { useTranslation } from "react-i18next"
 
@@ -32,14 +30,6 @@ function SwapBTC(): ReactElement {
   const { t } = useTranslation()
   const [poolData] = usePoolData(BTC_POOL_NAME)
   const approveAndSwap = useApproveAndSwap(BTC_POOL_NAME)
-  const {
-    slippageCustom,
-    slippageSelected,
-    gasPriceSelected,
-    gasCustom,
-    infiniteApproval,
-    transactionDeadline,
-  } = useSelector((state: AppState) => state.user)
   const tokenBalances = usePoolTokenBalances(BTC_POOL_NAME)
   const swapContract = useSwapContract(BTC_POOL_NAME)
   const [formState, setFormState] = useState<FormState>({
@@ -213,12 +203,6 @@ function SwapBTC(): ReactElement {
       fromTokenSymbol: formState.from.symbol,
       toAmount: formState.to.value,
       toTokenSymbol: formState.to.symbol,
-      slippageCustom,
-      slippageSelected,
-      infiniteApproval,
-      gasPriceSelected,
-      gasCustom,
-      transactionDeadline,
     })
     // Clear input after deposit
     setFormState((prevState) => ({

--- a/src/pages/WithdrawBTC.tsx
+++ b/src/pages/WithdrawBTC.tsx
@@ -19,12 +19,9 @@ function WithdrawBTC(): ReactElement {
   const [withdrawFormState, updateWithdrawFormState] = useWithdrawFormState(
     BTC_POOL_NAME,
   )
-  const {
-    slippageCustom,
-    slippageSelected,
-    infiniteApproval,
-    transactionDeadline,
-  } = useSelector((state: AppState) => state.user)
+  const { slippageCustom, slippageSelected } = useSelector(
+    (state: AppState) => state.user,
+  )
   const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
   const approveAndWithdraw = useApproveAndWithdraw(BTC_POOL_NAME)
   const swapContract = useSwapContract(BTC_POOL_NAME)
@@ -81,9 +78,7 @@ function WithdrawBTC(): ReactElement {
     } = withdrawFormState
     await approveAndWithdraw({
       tokenFormState: tokenInputs,
-      infiniteApproval,
       withdrawType,
-      transactionDeadline,
       lpTokenAmountToSpend,
     })
     updateWithdrawFormState({ fieldName: "reset", value: "reset" })

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,11 +1,14 @@
 import { configureStore, getDefaultMiddleware } from "@reduxjs/toolkit"
 import { load, save } from "redux-localstorage-simple"
+import user, { initialState as userInitialState } from "./user"
 
 import application from "./application"
-import user from "./user"
+import { merge } from "lodash"
 
 const PERSISTED_KEYS: string[] = ["user"]
-
+const stateFromStorage = load({
+  states: PERSISTED_KEYS,
+})
 const store = configureStore({
   reducer: {
     application,
@@ -15,7 +18,7 @@ const store = configureStore({
     ...getDefaultMiddleware({ thunk: false }),
     save({ states: PERSISTED_KEYS }),
   ],
-  preloadedState: load({ states: PERSISTED_KEYS }),
+  preloadedState: merge({}, { user: userInitialState }, stateFromStorage),
 })
 
 export default store

--- a/src/state/user.ts
+++ b/src/state/user.ts
@@ -20,9 +20,9 @@ export enum Slippages {
 }
 
 export enum Deadlines {
-  Ten = 10,
-  Thirty = 30,
-  Custom,
+  Ten = "TEN",
+  Thirty = "THIRTY",
+  Custom = "CUSTOM",
 }
 
 interface UserState {
@@ -34,17 +34,18 @@ interface UserState {
   slippageCustom?: NumberInputState
   slippageSelected: Slippages
   infiniteApproval: boolean
-  transactionDeadline: Deadlines
+  transactionDeadlineSelected: Deadlines
+  transactionDeadlineCustom?: string
 }
 
-const initialState: UserState = {
+export const initialState: UserState = {
   userSwapAdvancedMode: false,
   userPoolAdvancedMode: false,
   userDarkMode: false,
   gasPriceSelected: GasPrices.Standard,
   slippageSelected: Slippages.OneTenth,
   infiniteApproval: false,
-  transactionDeadline: Deadlines.Ten,
+  transactionDeadlineSelected: Deadlines.Ten,
 }
 
 const gasCustomStateCreator = numberInputStateCreator(
@@ -114,11 +115,21 @@ const userSlice = createSlice({
     ): void {
       state.infiniteApproval = action.payload
     },
-    updateTransactionDeadline(
+    updateTransactionDeadlineSelected(
       state: UserState,
       action: PayloadAction<Deadlines>,
     ): void {
-      state.transactionDeadline = action.payload
+      state.transactionDeadlineSelected = action.payload
+      // clear custom value when standard option selected
+      if (action.payload !== Deadlines.Custom) {
+        state.transactionDeadlineCustom = ""
+      }
+    },
+    updateTransactionDeadlineCustom(
+      state: UserState,
+      action: PayloadAction<string>,
+    ): void {
+      state.transactionDeadlineCustom = action.payload
     },
   },
 })
@@ -132,7 +143,8 @@ export const {
   updateSlippageCustom,
   updateSlippageSelected,
   updateInfiniteApproval,
-  updateTransactionDeadline,
+  updateTransactionDeadlineSelected,
+  updateTransactionDeadlineCustom,
 } = userSlice.actions
 
 export default userSlice.reducer

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -4,6 +4,7 @@ import { AddressZero } from "@ethersproject/constants"
 import { BigNumber } from "@ethersproject/bignumber"
 import { Contract } from "@ethersproject/contracts"
 import { ContractInterface } from "ethers"
+import { Deadlines } from "../state/user"
 import { formatUnits } from "@ethersproject/units"
 import { getAddress } from "@ethersproject/address"
 
@@ -85,4 +86,19 @@ export function calculateExchangeRate(
         .mul(BigNumber.from(10).pow(36 - tokenPrecisionTo)) // convert to standard 1e18 precision
         .div(amountFrom.mul(BigNumber.from(10).pow(18 - tokenPrecisionFrom)))
     : BigNumber.from("0")
+}
+
+export function formatDeadlineToNumber(
+  deadlineSelected: Deadlines,
+  deadlineCustom?: string,
+): number {
+  let deadline
+  if (deadlineSelected === Deadlines.Thirty) {
+    deadline = 30
+  } else if (deadlineSelected === Deadlines.Custom) {
+    deadline = +(deadlineCustom || 10)
+  } else {
+    deadline = 10
+  }
+  return deadline
 }


### PR DESCRIPTION
See [slack](https://saddle-finance.slack.com/archives/C017XJU4GSJ/p1614222819021900) for issue details.

We were incorrectly merging static `initialState` with state pulled from `localStorage` while hydrating redux. As a result, some users did not have a `transactionDeadline`, which consequently caused their transactions to fail (before even reaching the contract, so no gas was spent). 

This PR does 3 things in order of importance:
1) Corrects how `initialState` is merged into localstorage state in redux
2) Adjusts the implementation of `deadlines` to match that of `slippage` and `gas` (eg using `selected` and `custom` states) which also fixes a minor bug (type 10 or 30 into the custom deadline field in prod to see)
3) Moves Deadlines, gas, and slippage from props to being accessed from the redux store in all `useApproveAnd[Swap|Deposit|Withdraw]` functions