### PR TITLE
Make existing pages generic w/ poolName prop

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -64,6 +64,13 @@ export const MERKLETREE_DATA: { [chainId in ChainId]: string } = {
   [ChainId.HARDHAT]: "hardhat.json",
 }
 
+export const STABLECOIN_SWAP_TOKEN_CONTRACT_ADDRESSES: {
+  [chainId in ChainId]: string
+} = {
+  [ChainId.MAINNET]: "",
+  [ChainId.HARDHAT]: "0x6A358FD7B7700887b0cd974202CdF93208F793E2",
+}
+
 export const BTC_SWAP_TOKEN_CONTRACT_ADDRESSES: {
   [chainId in ChainId]: string
 } = {
@@ -74,9 +81,18 @@ export const BTC_SWAP_TOKEN_CONTRACT_ADDRESSES: {
 export const BTC_SWAP_TOKEN = new Token(
   BTC_SWAP_TOKEN_CONTRACT_ADDRESSES,
   18,
-  "BLPT",
-  "blpt",
-  "Saddle BTC Pool LP Token",
+  "saddleBTC",
+  "saddlebtc",
+  "Saddle TBTC/WBTC/RENBTC/SBTC",
+  saddleLogo,
+)
+
+export const STABLECOIN_SWAP_TOKEN = new Token(
+  STABLECOIN_SWAP_TOKEN_CONTRACT_ADDRESSES,
+  18,
+  "saddleUSD",
+  "saddleusd",
+  "Saddle DAI/USDC/USDT",
   saddleLogo,
 )
 
@@ -199,10 +215,19 @@ export const TOKENS_MAP: {
 )
 
 export const POOLS_MAP: {
-  [poolName: string]: Token[]
+  [poolName in PoolName]: {
+    lpToken: Token
+    poolTokens: Token[]
+  }
 } = {
-  [BTC_POOL_NAME]: BTC_POOL_TOKENS,
-  [STABLECOIN_POOL_NAME]: STABLECOIN_POOL_TOKENS,
+  [BTC_POOL_NAME]: {
+    lpToken: BTC_SWAP_TOKEN,
+    poolTokens: BTC_POOL_TOKENS,
+  },
+  [STABLECOIN_POOL_NAME]: {
+    lpToken: STABLECOIN_SWAP_TOKEN,
+    poolTokens: STABLECOIN_POOL_TOKENS,
+  },
 }
 
 export const TRANSACTION_TYPES = {

--- a/src/hooks/useApproveAndWithdraw.ts
+++ b/src/hooks/useApproveAndWithdraw.ts
@@ -42,9 +42,7 @@ export function useApproveAndWithdraw(
     infiniteApproval,
   } = useSelector((state: AppState) => state.user)
   const lpTokenContract = useLPTokenContract(poolName)
-  const POOL_TOKENS = POOLS_MAP[poolName]
-  if (!POOL_TOKENS)
-    throw new Error("useApproveAndWithdraw requires a valid pool name")
+  const POOL = POOLS_MAP[poolName]
 
   return async function approveAndWithdraw(
     state: ApproveAndWithdrawStateArgument,
@@ -122,7 +120,7 @@ export function useApproveAndWithdraw(
       if (state.withdrawType === "ALL") {
         spendTransaction = await swapContract.removeLiquidity(
           state.lpTokenAmountToSpend,
-          POOL_TOKENS.map(({ symbol }) =>
+          POOL.poolTokens.map(({ symbol }) =>
             subtractSlippage(
               BigNumber.from(state.tokenFormState[symbol].valueSafe),
               slippageSelected,
@@ -136,7 +134,7 @@ export function useApproveAndWithdraw(
         )
       } else if (state.withdrawType === "IMBALANCE") {
         spendTransaction = await swapContract.removeLiquidityImbalance(
-          POOL_TOKENS.map(
+          POOL.poolTokens.map(
             ({ symbol }) => state.tokenFormState[symbol].valueSafe,
           ),
           addSlippage(
@@ -153,7 +151,9 @@ export function useApproveAndWithdraw(
         // state.withdrawType === [TokenSymbol]
         spendTransaction = await swapContract.removeLiquidityOneToken(
           state.lpTokenAmountToSpend,
-          POOL_TOKENS.findIndex(({ symbol }) => symbol === state.withdrawType),
+          POOL.poolTokens.findIndex(
+            ({ symbol }) => symbol === state.withdrawType,
+          ),
           subtractSlippage(
             BigNumber.from(
               state.tokenFormState[state.withdrawType || ""].valueSafe,

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -6,7 +6,9 @@ import {
   PoolName,
   RENBTC,
   SBTC,
+  STABLECOIN_POOL_NAME,
   STABLECOIN_SWAP_ADDRESSES,
+  STABLECOIN_SWAP_TOKEN,
   SUSD,
   TBTC,
   Token,
@@ -75,9 +77,10 @@ export function useSwapContract(poolName: PoolName): Swap | null {
   return useMemo(() => {
     if (poolName === BTC_POOL_NAME) {
       return btcSwapContract as Swap
-    } else {
+    } else if (poolName === STABLECOIN_POOL_NAME) {
       return stablecoinSwapContract as Swap
     }
+    return null
   }, [stablecoinSwapContract, btcSwapContract, poolName])
 }
 
@@ -103,6 +106,9 @@ export function useAllContracts(): AllContractsObject | null {
   const usdtContract = useTokenContract(USDT) as Erc20
   const susdContract = useTokenContract(SUSD) as Erc20
   const btcSwapTokenContract = useTokenContract(BTC_SWAP_TOKEN) as Swap
+  const stablecoinSwapTokenContract = useTokenContract(
+    STABLECOIN_SWAP_TOKEN,
+  ) as Swap
 
   return useMemo(() => {
     if (
@@ -116,6 +122,7 @@ export function useAllContracts(): AllContractsObject | null {
         usdtContract,
         susdContract,
         btcSwapTokenContract,
+        // stablecoinSwapTokenContract, // TODO: add back when contract deployed
       ].some(Boolean)
     )
       return null
@@ -129,6 +136,7 @@ export function useAllContracts(): AllContractsObject | null {
       [USDT.symbol]: usdtContract,
       [SUSD.symbol]: susdContract,
       [BTC_SWAP_TOKEN.symbol]: btcSwapTokenContract,
+      [STABLECOIN_SWAP_TOKEN.symbol]: stablecoinSwapTokenContract,
     }
   }, [
     tbtcContract,
@@ -140,5 +148,6 @@ export function useAllContracts(): AllContractsObject | null {
     usdtContract,
     susdContract,
     btcSwapTokenContract,
+    stablecoinSwapTokenContract,
   ])
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,16 +1,16 @@
 import "../styles/global.scss"
 
+import { BLOCK_TIME, BTC_POOL_NAME } from "../constants"
 import React, { ReactElement, Suspense, useCallback } from "react"
 import { Route, Switch } from "react-router-dom"
 
 import { AppDispatch } from "../state"
-import { BLOCK_TIME } from "../constants"
-import DepositBTC from "./DepositBTC"
+import Deposit from "./Deposit"
 import Risk from "./Risk"
-import SwapBTC from "./SwapBTC"
+import Swap from "./Swap"
 import ToastsProvider from "../providers/ToastsProvider"
 import Web3ReactManager from "../components/Web3ReactManager"
-import WithdrawBTC from "./WithdrawBTC"
+import Withdraw from "./Withdraw"
 import fetchGasPrices from "../utils/updateGasPrices"
 import fetchTokenPricesUSD from "../utils/updateTokenPrices"
 import { useDispatch } from "react-redux"
@@ -33,9 +33,25 @@ export default function App(): ReactElement {
       <Web3ReactManager>
         <ToastsProvider>
           <Switch>
-            <Route exact path="/" component={SwapBTC} />
-            <Route exact path="/deposit" component={DepositBTC} />
-            <Route exact path="/withdraw" component={WithdrawBTC} />
+            <Route
+              exact
+              path="/"
+              render={(props) => <Swap {...props} poolName={BTC_POOL_NAME} />}
+            />
+            <Route
+              exact
+              path="/deposit"
+              render={(props) => (
+                <Deposit {...props} poolName={BTC_POOL_NAME} />
+              )}
+            />
+            <Route
+              exact
+              path="/withdraw"
+              render={(props) => (
+                <Withdraw {...props} poolName={BTC_POOL_NAME} />
+              )}
+            />
             <Route exact path="/risk" component={Risk} />
           </Switch>
         </ToastsProvider>

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -1,4 +1,4 @@
-import { BTC_POOL_NAME, BTC_POOL_TOKENS, TOKENS_MAP } from "../constants"
+import { POOLS_MAP, PoolName, TOKENS_MAP } from "../constants"
 import React, { ReactElement, useCallback, useState } from "react"
 import { formatUnits, parseUnits } from "@ethersproject/units"
 
@@ -26,27 +26,31 @@ interface FormState {
   priceImpact: BigNumber
   exchangeRate: BigNumber
 }
-function SwapBTC(): ReactElement {
+interface Props {
+  poolName: PoolName
+}
+function Swap({ poolName }: Props): ReactElement {
   const { t } = useTranslation()
-  const [poolData] = usePoolData(BTC_POOL_NAME)
-  const approveAndSwap = useApproveAndSwap(BTC_POOL_NAME)
-  const tokenBalances = usePoolTokenBalances(BTC_POOL_NAME)
-  const swapContract = useSwapContract(BTC_POOL_NAME)
+  const [poolData] = usePoolData(poolName)
+  const approveAndSwap = useApproveAndSwap(poolName)
+  const tokenBalances = usePoolTokenBalances(poolName)
+  const swapContract = useSwapContract(poolName)
+  const POOL = POOLS_MAP[poolName]
   const [formState, setFormState] = useState<FormState>({
     error: null,
     from: {
-      symbol: BTC_POOL_TOKENS[0].symbol,
+      symbol: POOL.poolTokens[0].symbol,
       value: "0.0",
     },
     to: {
-      symbol: BTC_POOL_TOKENS[1].symbol,
+      symbol: POOL.poolTokens[1].symbol,
       value: BigNumber.from("0"),
     },
     priceImpact: BigNumber.from("0"),
     exchangeRate: BigNumber.from("0"),
   })
   // build a representation of pool tokens for the UI
-  const tokens = BTC_POOL_TOKENS.map(({ symbol, name, icon, decimals }) => ({
+  const tokens = POOL.poolTokens.map(({ symbol, name, icon, decimals }) => ({
     name,
     icon,
     symbol,
@@ -71,10 +75,10 @@ function SwapBTC(): ReactElement {
         return
       }
       // TODO: improve the relationship between token / index
-      const tokenIndexFrom = BTC_POOL_TOKENS.findIndex(
+      const tokenIndexFrom = POOL.poolTokens.findIndex(
         ({ symbol }) => symbol === formStateArg.from.symbol,
       )
-      const tokenIndexTo = BTC_POOL_TOKENS.findIndex(
+      const tokenIndexTo = POOL.poolTokens.findIndex(
         ({ symbol }) => symbol === formStateArg.to.symbol,
       )
       const amountToGive = parseUnits(
@@ -246,4 +250,4 @@ function SwapBTC(): ReactElement {
   )
 }
 
-export default SwapBTC
+export default Swap

--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -1,10 +1,13 @@
-import { BLOCK_TIME, Token } from "../../constants"
+import { BLOCK_TIME, DAI, STABLECOIN_POOL_NAME, Token } from "../../constants"
 import {
   BTC_POOL_NAME,
   PoolName,
   RENBTC,
   SBTC,
+  SUSD,
   TBTC,
+  USDC,
+  USDT,
   WBTC,
 } from "../../constants"
 
@@ -44,21 +47,36 @@ export function usePoolTokenBalances(
   poolName: PoolName,
 ): { [token: string]: BigNumber } | null {
   const tbtcTokenBalance = useTokenBalance(TBTC)
-  const wtcTokenBalance = useTokenBalance(WBTC)
+  const wbtcTokenBalance = useTokenBalance(WBTC)
   const renbtcTokenBalance = useTokenBalance(RENBTC)
   const sbtcTokenBalance = useTokenBalance(SBTC)
+  const daiTokenBalance = useTokenBalance(DAI)
+  const usdcTokenBalance = useTokenBalance(USDC)
+  const usdtTokenBalance = useTokenBalance(USDT)
+  const susdTokenBalance = useTokenBalance(SUSD)
   const btcPoolTokenBalances = useMemo(
     () => ({
       [TBTC.symbol]: tbtcTokenBalance,
-      [WBTC.symbol]: wtcTokenBalance,
+      [WBTC.symbol]: wbtcTokenBalance,
       [RENBTC.symbol]: renbtcTokenBalance,
       [SBTC.symbol]: sbtcTokenBalance,
     }),
-    [tbtcTokenBalance, wtcTokenBalance, renbtcTokenBalance, sbtcTokenBalance],
+    [tbtcTokenBalance, wbtcTokenBalance, renbtcTokenBalance, sbtcTokenBalance],
+  )
+  const stablecoinPoolTokenBalances = useMemo(
+    () => ({
+      [DAI.symbol]: daiTokenBalance,
+      [USDC.symbol]: usdcTokenBalance,
+      [USDT.symbol]: usdtTokenBalance,
+      [SUSD.symbol]: susdTokenBalance,
+    }),
+    [daiTokenBalance, usdcTokenBalance, usdtTokenBalance, susdTokenBalance],
   )
 
   if (poolName === BTC_POOL_NAME) {
     return btcPoolTokenBalances
+  } else if (poolName === STABLECOIN_POOL_NAME) {
+    return stablecoinPoolTokenBalances
   }
   return null
 }


### PR DESCRIPTION
Remove hardcoded poolnames from top level pages, replace with `poolName` prop. Check `App.tsx` for how this is used.
Tested and working locally on a branch of the contract repo before some recent changes to the local environment. 