### PR TITLE
Zero values instead of contract data when no user wallet connected

### DIFF
--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -13,7 +13,7 @@ import { useTranslation } from "react-i18next"
 
 interface Props {
   to: string
-  poolData: PoolDataType | null
+  poolData: PoolDataType
   userShareData: UserShareType | null
 }
 
@@ -23,11 +23,10 @@ function PoolOverview({
   userShareData,
 }: Props): ReactElement | null {
   const { t } = useTranslation()
-  if (poolData == null) return null
   const formattedData = {
     name: poolData.name,
     reserve: `$${commify(formatBNToString(poolData.reserve, 18, 2))}`,
-    apr: formatBNToPercentString(poolData.keepApr || Zero, 18),
+    apr: formatBNToPercentString(poolData.keepApr, 18),
     userBalanceUSD: `$${commify(
       formatBNToString(userShareData?.usdBalance || Zero, 18, 2),
     )}`,
@@ -59,7 +58,7 @@ function PoolOverview({
           </div>
 
           <div className="right">
-            {poolData.keepApr.gt(Zero) && (
+            {poolData?.keepApr.gt(Zero) && (
               <div className="Apr">
                 <span className="label">KEEP APR</span>
                 <span


### PR DESCRIPTION
Since we're unable to interact with contracts when the user is not connected to a wallet, just show 0 values for everything to give a less broken experience. Additionally, display the "connect wallet" modal on every page until the user connects a wallet. 

<img width="1211" alt="Screen Shot 2021-03-29 at 9 14 21 AM" src="https://user-images.githubusercontent.com/7607886/112868354-d2110600-9070-11eb-9a82-bc3500751536.png">
<img width="1184" alt="Screen Shot 2021-03-29 at 9 14 57 AM" src="https://user-images.githubusercontent.com/7607886/112868363-d50bf680-9070-11eb-837c-4dbe7e6af7e7.png">
<img width="1196" alt="Screen Shot 2021-03-29 at 9 14 39 AM" src="https://user-images.githubusercontent.com/7607886/112868364-d63d2380-9070-11eb-9a0d-4f7caa5df53c.png">
