### PR TITLE
Fix missing pool data when no wallet connected

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -1,8 +1,9 @@
+import { BaseProvider, getDefaultProvider } from "@ethersproject/providers"
+
 import { InjectedConnector } from "@web3-react/injected-connector"
 import { NetworkConnector } from "@web3-react/network-connector"
 import { WalletConnectConnector } from "@web3-react/walletconnect-connector"
 import { WalletLinkConnector } from "@web3-react/walletlink-connector"
-import { Web3Provider } from "@ethersproject/providers"
 
 const NETWORK_URL = process.env.REACT_APP_NETWORK_URL
 export const NETWORK_CHAIN_ID: number = parseInt(
@@ -19,12 +20,10 @@ export const network = new NetworkConnector({
   urls: { [NETWORK_CHAIN_ID]: NETWORK_URL },
 })
 
-// eslint-disable-next-line @typescript-eslint/unbound-method
-const { getProvider } = network
-
-let networkLibrary: Web3Provider | undefined
-export function getNetworkLibrary(): Web3Provider {
-  return (networkLibrary = networkLibrary ?? new Web3Provider(getProvider))
+let networkLibrary: BaseProvider | undefined
+export function getNetworkLibrary(): BaseProvider {
+  const provider = getDefaultProvider(NETWORK_URL)
+  return (networkLibrary = networkLibrary ?? provider)
 }
 
 export const injected = new InjectedConnector({

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -103,8 +103,7 @@ export default function usePoolData(
         poolName == null ||
         swapContract == null ||
         tokenPricesUSD == null ||
-        library == null ||
-        account == null
+        library == null
       )
         return
 

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -139,7 +139,7 @@ export default function usePoolData(
             ) as KeepLPRewards)
           : { balanceOf: () => Promise.resolve(Zero) }
       const lpTokenAmountStakedOnKeep =
-        poolName === BTC_POOL_NAME
+        poolName === BTC_POOL_NAME && account != null
           ? await keepLPRewardsContract.balanceOf(account)
           : Zero
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import ReactDOM from "react-dom"
 import { HashRouter as Router } from "react-router-dom"
 import chakraTheme from "./theme/"
 import getLibrary from "./utils/getLibrary"
+import { getNetworkLibrary } from "./connectors"
 import reportWebVitals from "./reportWebVitals"
 import store from "./state"
 
@@ -30,7 +31,7 @@ ReactDOM.render(
     <React.StrictMode>
       <ChakraProvider theme={chakraTheme}>
         <Web3ReactProvider getLibrary={getLibrary}>
-          <Web3ProviderNetwork getLibrary={getLibrary}>
+          <Web3ProviderNetwork getLibrary={getNetworkLibrary}>
             <Provider store={store}>
               <Router>
                 <App />

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -1,19 +1,11 @@
 import "../styles/global.scss"
 
 import { BLOCK_TIME, BTC_POOL_NAME, STABLECOIN_POOL_NAME } from "../constants"
-import React, {
-  ReactElement,
-  Suspense,
-  useCallback,
-  useEffect,
-  useState,
-} from "react"
-import { Route, Switch, useLocation } from "react-router-dom"
+import React, { ReactElement, Suspense, useCallback } from "react"
+import { Route, Switch } from "react-router-dom"
 
 import { AppDispatch } from "../state"
-import ConnectWallet from "../components/ConnectWallet"
 import Deposit from "./Deposit"
-import Modal from "../components/Modal"
 import Pools from "./Pools"
 import Risk from "./Risk"
 import Swap from "./Swap"
@@ -22,20 +14,11 @@ import Web3ReactManager from "../components/Web3ReactManager"
 import Withdraw from "./Withdraw"
 import fetchGasPrices from "../utils/updateGasPrices"
 import fetchTokenPricesUSD from "../utils/updateTokenPrices"
-import { useActiveWeb3React } from "../hooks/"
 import { useDispatch } from "react-redux"
 import usePoller from "../hooks/usePoller"
 
 export default function App(): ReactElement {
   const dispatch = useDispatch<AppDispatch>()
-  const { pathname } = useLocation()
-  const { account } = useActiveWeb3React()
-  const [isModalOpen, setIsModalOpen] = useState(false)
-  // show ConnectWallet modal on each new page if not connected to wallet
-  useEffect(() => {
-    const shouldShowModal = !account && pathname !== "/risk"
-    setIsModalOpen(shouldShowModal)
-  }, [pathname, account])
 
   const fetchAndUpdateGasPrice = useCallback(() => {
     void fetchGasPrices(dispatch)
@@ -50,12 +33,6 @@ export default function App(): ReactElement {
     <Suspense fallback={null}>
       <Web3ReactManager>
         <ToastsProvider>
-          <Modal
-            isOpen={isModalOpen}
-            onClose={(): void => setIsModalOpen(false)}
-          >
-            <ConnectWallet onClose={(): void => setIsModalOpen(false)} />
-          </Modal>
           <Switch>
             <Route exact path="/" component={Swap} />
             <Route


### PR DESCRIPTION
- switch from web3provider to getDefaultProvider, which appears to fix the malformed rpc requests
- turn off "no wallet connected" modals