### PR TITLE
Change the sequential approvals to concurrent ones

### DIFF
--- a/src/hooks/useApproveAndDeposit.ts
+++ b/src/hooks/useApproveAndDeposit.ts
@@ -99,9 +99,9 @@ export function useApproveAndDeposit(
     }
     try {
       // For each token being deposited, check the allowance and approve it if necessary
-      for (const token of POOL.poolTokens) {
-        await approveSingleToken(token)
-      }
+      await Promise.all(
+        POOL.poolTokens.map((token) => approveSingleToken(token)),
+      )
 
       // "isFirstTransaction" check can be removed after launch
       const poolTokenBalances: BigNumber[] = await Promise.all(


### PR DESCRIPTION
Since MetaMask has fixed the issue with their v.9.2.1 release (13 days ago), we should change the approvals back to concurrent ones for a better UX.

https://github.com/MetaMask/metamask-extension/releases/tag/v9.2.1

