### PR TITLE
Update contract addresses

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -57,17 +57,17 @@ export const BLOCK_TIME = 15000
 
 export const STABLECOIN_SWAP_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0x3911F80530595fBd01Ab1516Ab61255d75AEb066",
-  [ChainId.HARDHAT]: "0x856e4424f806D16E8CBC702B3c0F2ede5468eae5",
+  [ChainId.HARDHAT]: "0xCafac3dD18aC6c6e92c921884f9E4176737C052c",
 }
 
 export const BTC_SWAP_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0x4f6A43Ad7cba042606dECaCA730d4CE0A57ac62e",
-  [ChainId.HARDHAT]: "0x0B306BF915C4d645ff596e518fAf3F9669b97016",
+  [ChainId.HARDHAT]: "0x610178dA211FEF7D417bC0e6FeD39F05609AD788",
 }
 
 export const VETH2_SWAP_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xdec2157831D6ABC3Ec328291119cc91B337272b5",
-  [ChainId.HARDHAT]: "0xb0279Db6a2F1E01fbC8483FCCef0Be2bC6299cC3",
+  [ChainId.HARDHAT]: "0x9f1ac54BEF0DD2f6f3462EA0fa94fC62300d3a8e",
 }
 
 export const MERKLETREE_DATA: { [chainId in ChainId]: string } = {
@@ -79,21 +79,21 @@ export const STABLECOIN_SWAP_TOKEN_CONTRACT_ADDRESSES: {
   [chainId in ChainId]: string
 } = {
   [ChainId.MAINNET]: "0x76204f8CFE8B95191A3d1CfA59E267EA65e06FAC",
-  [ChainId.HARDHAT]: "0x63f84713F52422Af2F8E18b56703b0f80CCcCBcE",
+  [ChainId.HARDHAT]: "0xAe367415f4BDe0aDEE3e59C35221d259f517413E",
 }
 
 export const BTC_SWAP_TOKEN_CONTRACT_ADDRESSES: {
   [chainId in ChainId]: string
 } = {
   [ChainId.MAINNET]: "0xC28DF698475dEC994BE00C9C9D8658A548e6304F",
-  [ChainId.HARDHAT]: "0x524F04724632eED237cbA3c37272e018b3A7967e",
+  [ChainId.HARDHAT]: "0x6F1216D1BFe15c98520CA1434FC1d9D57AC95321",
 }
 
 export const VETH2_SWAP_TOKEN_CONTRACT_ADDRESSES: {
   [chainId in ChainId]: string
 } = {
   [ChainId.MAINNET]: "0xe37E2a01feA778BC1717d72Bd9f018B6A6B241D5",
-  [ChainId.HARDHAT]: "0x8C1f1Ab0b323c4B4FCb9F85CE8beCbCD6F673d43",
+  [ChainId.HARDHAT]: "0x2d2c18F63D2144161B38844dCd529124Fbb93cA2",
 }
 
 export const BTC_SWAP_TOKEN = new Token(
@@ -126,7 +126,7 @@ export const VETH2_SWAP_TOKEN = new Token(
 // Stablecoins
 const DAI_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0x6B175474E89094C44Da98b954EedeAC495271d0F",
-  [ChainId.HARDHAT]: "0x9A9f2CCfdE556A7E9Ff0848998Aa4a0CFD8863AE",
+  [ChainId.HARDHAT]: "0xA51c1fc2f0D1a1b8494Ed1FE312d7C3a78Ed91C0",
 }
 export const DAI = new Token(
   DAI_CONTRACT_ADDRESSES,
@@ -139,7 +139,7 @@ export const DAI = new Token(
 
 const USDC_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-  [ChainId.HARDHAT]: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
+  [ChainId.HARDHAT]: "0x9A676e781A523b5d0C0e43731313A708CB607508",
 }
 export const USDC = new Token(
   USDC_CONTRACT_ADDRESSES,
@@ -152,7 +152,7 @@ export const USDC = new Token(
 
 const USDT_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xdac17f958d2ee523a2206206994597c13d831ec7",
-  [ChainId.HARDHAT]: "0x59b670e9fA9D0A427751Af201D676719a970857b",
+  [ChainId.HARDHAT]: "0x959922bE3CAee4b8Cd9a407cc3ac1C251C2007B1",
 }
 export const USDT = new Token(
   USDT_CONTRACT_ADDRESSES,
@@ -168,7 +168,7 @@ export const STABLECOIN_POOL_TOKENS = [DAI, USDC, USDT]
 // Tokenized BTC
 const TBTC_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0x8daebade922df735c38c80c7ebd708af50815faa",
-  [ChainId.HARDHAT]: "0xa513E6E4b8f2a923D98304ec87F64353C4D5C853",
+  [ChainId.HARDHAT]: "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0",
 }
 export const TBTC = new Token(
   TBTC_CONTRACT_ADDRESSES,
@@ -181,7 +181,7 @@ export const TBTC = new Token(
 
 const WBTC_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0x2260fac5e5542a773aa44fbcfedf7c193bc2c599",
-  [ChainId.HARDHAT]: "0x8A791620dd6260079BF849Dc5567aDC3F2FdC318",
+  [ChainId.HARDHAT]: "0xDc64a140Aa3E981100a9becA4E685f962f0cF6C9",
 }
 export const WBTC = new Token(
   WBTC_CONTRACT_ADDRESSES,
@@ -194,7 +194,7 @@ export const WBTC = new Token(
 
 const RENBTC_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xeb4c2781e4eba804ce9a9803c67d0893436bb27d",
-  [ChainId.HARDHAT]: "0xB7f8BC63BbcaD18155201308C8f3540b07f84F5e",
+  [ChainId.HARDHAT]: "0x0165878A594ca255338adfa4d48449f69242Eb8F",
 }
 export const RENBTC = new Token(
   RENBTC_CONTRACT_ADDRESSES,
@@ -207,7 +207,7 @@ export const RENBTC = new Token(
 
 const SBTC_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6",
-  [ChainId.HARDHAT]: "0x0DCd1Bf9A1b36cE34237eEaFef220932846BCD82",
+  [ChainId.HARDHAT]: "0x2279B7A0a67DB372996a5FaB50D91eAA73d2eBe6",
 }
 export const SBTC = new Token(
   SBTC_CONTRACT_ADDRESSES,
@@ -222,7 +222,7 @@ export const BTC_POOL_TOKENS = [TBTC, WBTC, RENBTC, SBTC]
 
 const WETH_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",
-  [ChainId.HARDHAT]: "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f",
+  [ChainId.HARDHAT]: "0x3Aa5ebB10DC797CAC828524e59A333d0A371443c",
 }
 export const WETH = new Token(
   WETH_CONTRACT_ADDRESSES,
@@ -235,7 +235,7 @@ export const WETH = new Token(
 
 const VETH2_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0x898BAD2774EB97cF6b94605677F43b41871410B1",
-  [ChainId.HARDHAT]: "0x7a2088a1bFc9d81c55368AE168C2C02570cB814F",
+  [ChainId.HARDHAT]: "0x59b670e9fA9D0A427751Af201D676719a970857b",
 }
 export const VETH2 = new Token(
   VETH2_CONTRACT_ADDRESSES,


### PR DESCRIPTION
Contract addresses were updated with https://github.com/saddle-finance/saddle-contract/pull/357

With the above PR (deploying libraries from a separate account), frontend-relevant contract addresses should stay the same even after deploying new libraries / auxiliary contracts. 