### PR TITLE
Fetch Pending Swaps

### DIFF
--- a/src/components/SwapPage.scss
+++ b/src/components/SwapPage.scss
@@ -149,4 +149,33 @@ div.swapPage {
   .showError {
     display: block;
   }
+
+  .pendingSwaps {
+    width: 100%;
+    > .pendingSwapItem {
+      width: 100%;
+      border: 1px solid $primary-blue;
+      border-radius: 10px;
+      background: var(--primary-background);
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 16px 24px;
+      .swapDetails {
+        color: $primary-blue;
+        font-weight: 700;
+        font-size: 16px;
+      }
+      .swapTimeContainer {
+        display: flex;
+        align-items: center;
+        > svg {
+          margin-right: 10px;
+        }
+        span.time {
+          font-size: 16px;
+        }
+      }
+    }
+  }
 }

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -14,6 +14,7 @@ import GasField from "./GasField"
 import InfiniteApprovalField from "./InfiniteApprovalField"
 import Modal from "./Modal"
 import { PayloadAction } from "@reduxjs/toolkit"
+import { PendingSwap } from "../hooks/usePendingSwapData"
 import ReviewSwap from "./ReviewSwap"
 import SlippageField from "./SlippageField"
 import SwapInput from "./SwapInput"
@@ -46,6 +47,7 @@ interface Props {
   error: string | null
   fromState: { symbol: string; value: string; valueUSD: BigNumber }
   toState: { symbol: string; value: string; valueUSD: BigNumber }
+  pendingSwapData: PendingSwap[]
   onChangeFromToken: (tokenSymbol: string) => void
   onChangeFromAmount: (amount: string) => void
   onChangeToToken: (tokenSymbol: string) => void

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -23,6 +23,7 @@ import TopMenu from "./TopMenu"
 import { Zero } from "@ethersproject/constants"
 import classNames from "classnames"
 import { commify } from "../utils"
+import { formatUnits } from "@ethersproject/units"
 import { isHighPriceImpact } from "../utils/priceImpact"
 import { logEvent } from "../utils/googleAnalytics"
 import { updateSwapAdvancedMode } from "../state/user"
@@ -47,7 +48,7 @@ interface Props {
   error: string | null
   fromState: { symbol: string; value: string; valueUSD: BigNumber }
   toState: { symbol: string; value: string; valueUSD: BigNumber }
-  pendingSwapData: PendingSwap[]
+  pendingSwaps: PendingSwap[]
   onChangeFromToken: (tokenSymbol: string) => void
   onChangeFromAmount: (amount: string) => void
   onChangeToToken: (tokenSymbol: string) => void
@@ -65,6 +66,7 @@ const SwapPage = (props: Props): ReactElement => {
     error,
     fromState,
     toState,
+    pendingSwaps,
     onChangeFromToken,
     onChangeFromAmount,
     onChangeToToken,
@@ -240,6 +242,55 @@ const SwapPage = (props: Props): ReactElement => {
               </div>
             </div>
           </div>
+        </div>
+        <div className="pendingSwaps">
+          {pendingSwaps.map((pendingSwap) => {
+            const formattedSynthBalance = commify(
+              formatUnits(
+                pendingSwap.synthBalance,
+                pendingSwap.synthTokenFrom.decimals,
+              ),
+            )
+            return (
+              <div
+                className="pendingSwapItem"
+                key={pendingSwap.itemId?.toString()}
+              >
+                <span className="swapDetails">
+                  {formattedSynthBalance} {pendingSwap.synthTokenFrom.symbol}{" "}
+                  {"->"} {pendingSwap.tokenTo.symbol}
+                </span>
+                <div className="swapTimeContainer">
+                  <svg
+                    width="11"
+                    height="11"
+                    viewBox="0 0 11 11"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      clipRule="evenodd"
+                      d="M5.23467 1H5.5C7.98605 1 10 3.01525 10 5.49924C10 7.98311 7.98618 10 5.5 10C3.01388 10 1 7.98469 1 5.49924C1 4.30732 1.46423 3.22282 2.21973 2.41912L2.60641 2.78249C1.93974 3.49169 1.53066 4.4476 1.53066 5.49924C1.53066 7.69191 3.30721 9.46943 5.5 9.46943C7.69273 9.46943 9.46934 7.69046 9.46934 5.49924C9.46934 3.39724 7.83438 1.67581 5.76533 1.5393V2.96008H5.23467V1Z"
+                      fill="black"
+                      stroke="black"
+                      strokeWidth="0.3"
+                      strokeMiterlimit="10"
+                    />
+                    <path
+                      d="M5.76204 5.52774L5.76861 5.53328L5.77577 5.53804C5.82206 5.5688 5.85082 5.61957 5.84998 5.67802L5.84997 5.67802V5.68017C5.84997 5.77327 5.77431 5.85 5.67911 5.85C5.62153 5.85 5.56861 5.81994 5.53676 5.77321L5.53241 5.76682L5.52742 5.76091L4.26017 4.26001L5.76204 5.52774Z"
+                      fill="black"
+                      stroke="black"
+                      strokeWidth="0.3"
+                    />
+                  </svg>
+                  <span className="swapTime">
+                    {Math.ceil(pendingSwap.secondsRemaining / 60)} min.
+                  </span>
+                </div>
+              </div>
+            )
+          })}
         </div>
         <Center width="100%" py={6}>
           <Button

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -63,6 +63,10 @@ export class Token {
 }
 
 export const BLOCK_TIME = 15000
+export const DEPLOYED_BLOCK: { [chainId in ChainId]: string } = {
+  [ChainId.MAINNET]: "latest",
+  [ChainId.HARDHAT]: "0",
+}
 
 export const BRIDGE_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xf5059a5D33d5853360D16C683c16e67980206f36", // TODO replace once mainnet deploy goes out

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -62,11 +62,7 @@ export class Token {
   }
 }
 
-export const BLOCK_TIME = 15000
-export const DEPLOYED_BLOCK: { [chainId in ChainId]: string } = {
-  [ChainId.MAINNET]: "latest",
-  [ChainId.HARDHAT]: "0",
-}
+export const BLOCK_TIME = 13000 // ms
 
 export const BRIDGE_CONTRACT_ADDRESSES: { [chainId in ChainId]: string } = {
   [ChainId.MAINNET]: "0xf5059a5D33d5853360D16C683c16e67980206f36", // TODO replace once mainnet deploy goes out

--- a/src/hooks/usePendingSwapData.ts
+++ b/src/hooks/usePendingSwapData.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react"
+
+import { BigNumber } from "@ethersproject/bignumber"
+import { Bridge } from "../../types/ethers-contracts/Bridge"
+import { DEPLOYED_BLOCK } from "../constants"
+import { Event } from "ethers"
+import { hexZeroPad } from "@ethersproject/bytes"
+import { useActiveWeb3React } from "./"
+import { useBridgeContract } from "./useContract"
+
+export interface PendingSwap {
+  swapType: number
+  secsLeft: BigNumber
+  synth: string
+  synthBalance: BigNumber
+  tokenTo: string
+  itemId?: BigNumber
+}
+const VIRTUAL_SWAP_TOPICS = [
+  "TokenToSynth",
+  "SynthToToken",
+  "TokenToToken",
+] as const
+
+const usePendingSwapData = (): PendingSwap[] => {
+  const { account, library, chainId } = useActiveWeb3React()
+  const bridgeContract = useBridgeContract()
+  const [pendingSwaps, setPendingSwaps] = useState<PendingSwap[]>([])
+  const deployedBlock = chainId ? DEPLOYED_BLOCK[chainId] : 0
+
+  useEffect(() => {
+    async function fetchExistingPendingSwaps() {
+      if (!account || !library || !bridgeContract) return
+      const eventFilters = buildEventFilters(bridgeContract, account)
+      let events
+      events = await Promise.all(
+        eventFilters.map((filter) =>
+          bridgeContract.queryFilter(filter, deployedBlock, "latest"),
+        ),
+      )
+      events = events.flat()
+      const pendingSwapItemIds = events
+        .map(({ args }) => args?.itemId as BigNumber | null)
+        .filter(Boolean) as BigNumber[]
+      const fetchedPendingSwaps = await Promise.all(
+        pendingSwapItemIds.map((itemId) =>
+          fetchPendingSwapInfo(bridgeContract, itemId),
+        ),
+      )
+      setPendingSwaps(fetchedPendingSwaps.filter(Boolean) as PendingSwap[])
+    }
+    function attachPendingSwapEventListeners() {
+      if (!account || !library || !bridgeContract) return
+      const eventListener = (event: Event) => {
+        const newItemId = event.args?.itemId as BigNumber | null
+        if (newItemId == null) return
+        void fetchPendingSwapInfo(bridgeContract, newItemId).then(
+          (fetchedPendingSwap) => {
+            if (fetchedPendingSwap == null) return
+            setPendingSwaps((existingState) => {
+              // TODO: is deduping correct here?
+              return [
+                fetchedPendingSwap,
+                ...existingState.filter(({ itemId }) => itemId !== newItemId),
+              ]
+            })
+          },
+        )
+      }
+      VIRTUAL_SWAP_TOPICS.forEach((topic) => {
+        void bridgeContract.on(topic, eventListener)
+      })
+      return () => {
+        VIRTUAL_SWAP_TOPICS.forEach((topic) => {
+          bridgeContract.off(topic, eventListener)
+        })
+      }
+    }
+    void attachPendingSwapEventListeners()
+    void fetchExistingPendingSwaps()
+  }, [account, library, chainId, bridgeContract, deployedBlock])
+  return pendingSwaps
+}
+
+/**
+ * Create filters for each PendingSwap type
+ */
+function buildEventFilters(bridgeContract: Bridge, account: string) {
+  const args = [hexZeroPad(account, 32), null, null, null, null, null] as const
+  return VIRTUAL_SWAP_TOPICS.map((topic) =>
+    bridgeContract.filters[topic](...args),
+  )
+}
+
+async function fetchPendingSwapInfo(bridgeContract: Bridge, itemId: BigNumber) {
+  let pendingSwapInfo = null
+  try {
+    // this will throw if the itemId has already fully resolved
+    // afik we don't have a better way of fetching current pendingSwaps
+    pendingSwapInfo = await bridgeContract.getPendingSwapInfo(itemId)
+    pendingSwapInfo = { ...pendingSwapInfo, itemId }
+  } catch {
+    // do nothing because this is probably okay
+  }
+  return pendingSwapInfo
+}
+
+export default usePendingSwapData

--- a/src/hooks/usePendingSwapData.ts
+++ b/src/hooks/usePendingSwapData.ts
@@ -4,7 +4,6 @@ import { BigNumber } from "@ethersproject/bignumber"
 import { Bridge } from "../../types/ethers-contracts/Bridge"
 import { DEPLOYED_BLOCK } from "../constants"
 import { Event } from "ethers"
-import { hexZeroPad } from "@ethersproject/bytes"
 import { useActiveWeb3React } from "./"
 import { useBridgeContract } from "./useContract"
 
@@ -26,7 +25,7 @@ const usePendingSwapData = (): PendingSwap[] => {
   const { account, library, chainId } = useActiveWeb3React()
   const bridgeContract = useBridgeContract()
   const [pendingSwaps, setPendingSwaps] = useState<PendingSwap[]>([])
-  const deployedBlock = chainId ? DEPLOYED_BLOCK[chainId] : 0
+  const deployedBlock = chainId ? DEPLOYED_BLOCK[chainId] : "0"
 
   useEffect(() => {
     async function fetchExistingPendingSwaps() {
@@ -86,7 +85,7 @@ const usePendingSwapData = (): PendingSwap[] => {
  * Create filters for each PendingSwap type
  */
 function buildEventFilters(bridgeContract: Bridge, account: string) {
-  const args = [hexZeroPad(account, 32), null, null, null, null, null] as const
+  const args = [account, null, null, null, null, null] as const
   return VIRTUAL_SWAP_TOPICS.map((topic) =>
     bridgeContract.filters[topic](...args),
   )

--- a/src/hooks/usePendingSwapData.ts
+++ b/src/hooks/usePendingSwapData.ts
@@ -1,19 +1,27 @@
+import {
+  BLOCK_TIME,
+  ChainId,
+  IS_VIRTUAL_SWAP_ACTIVE,
+  SWAP_TYPES,
+  Token,
+} from "../constants"
 import { useEffect, useState } from "react"
 
 import { BigNumber } from "@ethersproject/bignumber"
 import { Bridge } from "../../types/ethers-contracts/Bridge"
-import { DEPLOYED_BLOCK } from "../constants"
 import { Event } from "ethers"
+import { getTokenByAddress } from "../utils"
 import { useActiveWeb3React } from "./"
 import { useBridgeContract } from "./useContract"
 
 export interface PendingSwap {
-  swapType: number
-  secsLeft: BigNumber
-  synth: string
+  swapType: SWAP_TYPES
+  settleableAtTimestamp: Date
+  secondsRemaining: number
+  synthTokenFrom: Token
   synthBalance: BigNumber
-  tokenTo: string
-  itemId?: BigNumber
+  tokenTo: Token
+  itemId: BigNumber
 }
 const VIRTUAL_SWAP_TOPICS = [
   "TokenToSynth",
@@ -25,47 +33,105 @@ const usePendingSwapData = (): PendingSwap[] => {
   const { account, library, chainId } = useActiveWeb3React()
   const bridgeContract = useBridgeContract()
   const [pendingSwaps, setPendingSwaps] = useState<PendingSwap[]>([])
-  const deployedBlock = chainId ? DEPLOYED_BLOCK[chainId] : "0"
+  const queryStartBlock =
+    chainId === ChainId.HARDHAT
+      ? 0
+      : -1 * Math.round((365 * 24 * 60 * 60 * 1000) / BLOCK_TIME) // approx number of blocks in 1 year
 
+  // update the secondsRemaining every 15s
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setPendingSwaps((swaps) =>
+        swaps.map((swap) => {
+          let secondsRemaining = Math.floor(
+            (swap.settleableAtTimestamp.getTime() - Date.now()) / 1000,
+          )
+          secondsRemaining = secondsRemaining > 0 ? secondsRemaining : 0
+          return { ...swap, secondsRemaining }
+        }),
+      )
+    }, 15 * 1000)
+    return () => {
+      clearInterval(timer)
+    }
+  }, [])
   useEffect(() => {
     async function fetchExistingPendingSwaps() {
-      if (!account || !library || !bridgeContract) return
+      if (
+        !IS_VIRTUAL_SWAP_ACTIVE ||
+        !account ||
+        !library ||
+        !bridgeContract ||
+        !chainId
+      )
+        return
+      // Step 1: build the filters to query for
       const eventFilters = buildEventFilters(bridgeContract, account)
+
+      // Step 2: run queries and get matching events
       let events
       events = await Promise.all(
         eventFilters.map((filter) =>
-          bridgeContract.queryFilter(filter, deployedBlock, "latest"),
+          bridgeContract.queryFilter(filter, queryStartBlock, "latest"),
         ),
       )
       events = events.flat()
-      const pendingSwapItemIds = events
-        .map(({ args }) => args?.itemId as BigNumber | null)
-        .filter(Boolean) as BigNumber[]
+      const eventBlocks = await Promise.all(
+        events.map((event) => event.getBlock()),
+      )
+
+      // Step 3: for each event, fetch the full pendingSwap from the contract
+      const pendingSwapItemIdsAndTimestamps = events
+        .map(({ args }, i) => [
+          args?.itemId as BigNumber | null,
+          eventBlocks[i].timestamp, // in seconds
+        ])
+        .filter(([itemId]) => Boolean(itemId)) as [BigNumber, number][]
       const fetchedPendingSwaps = await Promise.all(
-        pendingSwapItemIds.map((itemId) =>
-          fetchPendingSwapInfo(bridgeContract, itemId),
+        pendingSwapItemIdsAndTimestamps.map(([itemId, timestampInSeconds]) =>
+          fetchPendingSwapInfo(
+            bridgeContract,
+            itemId,
+            timestampInSeconds,
+            chainId,
+          ),
         ),
       )
+
+      // Step 4: write to state
       setPendingSwaps(fetchedPendingSwaps.filter(Boolean) as PendingSwap[])
     }
     function attachPendingSwapEventListeners() {
-      if (!account || !library || !bridgeContract) return
+      if (
+        !IS_VIRTUAL_SWAP_ACTIVE ||
+        !account ||
+        !library ||
+        !bridgeContract ||
+        !chainId
+      )
+        return
+
       const eventListener = (event: Event) => {
         const newItemId = event.args?.itemId as BigNumber | null
         if (newItemId == null) return
-        void fetchPendingSwapInfo(bridgeContract, newItemId).then(
-          (fetchedPendingSwap) => {
+        void event.getBlock().then((block) => {
+          void fetchPendingSwapInfo(
+            bridgeContract,
+            newItemId,
+            block.timestamp,
+            chainId,
+          ).then((fetchedPendingSwap) => {
             if (fetchedPendingSwap == null) return
             setPendingSwaps((existingState) => {
-              // TODO: is deduping correct here?
               return [
                 fetchedPendingSwap,
                 ...existingState.filter(({ itemId }) => itemId !== newItemId),
               ]
             })
-          },
-        )
+          })
+        })
       }
+
       VIRTUAL_SWAP_TOPICS.forEach((topic) => {
         void bridgeContract.on(topic, eventListener)
       })
@@ -77,7 +143,7 @@ const usePendingSwapData = (): PendingSwap[] => {
     }
     void attachPendingSwapEventListeners()
     void fetchExistingPendingSwaps()
-  }, [account, library, chainId, bridgeContract, deployedBlock])
+  }, [account, library, chainId, bridgeContract, queryStartBlock])
   return pendingSwaps
 }
 
@@ -85,23 +151,64 @@ const usePendingSwapData = (): PendingSwap[] => {
  * Create filters for each PendingSwap type
  */
 function buildEventFilters(bridgeContract: Bridge, account: string) {
-  const args = [account, null, null, null, null, null] as const
-  return VIRTUAL_SWAP_TOPICS.map((topic) =>
-    bridgeContract.filters[topic](...args),
-  )
+  return VIRTUAL_SWAP_TOPICS.map((topic) => {
+    return bridgeContract.filters[topic](account, null, null, null, null, null)
+  })
 }
 
-async function fetchPendingSwapInfo(bridgeContract: Bridge, itemId: BigNumber) {
-  let pendingSwapInfo = null
+enum BridgePendingSwapTypes {
+  Null,
+  TokenToSynth,
+  SynthToToken,
+  TokenToToken,
+}
+async function fetchPendingSwapInfo(
+  bridgeContract: Bridge,
+  itemId: BigNumber,
+  timestampInSeconds: number, // in seconds
+  chainId: ChainId,
+) {
+  let result = null
   try {
     // this will throw if the itemId has already fully resolved
     // afik we don't have a better way of fetching current pendingSwaps
-    pendingSwapInfo = await bridgeContract.getPendingSwapInfo(itemId)
-    pendingSwapInfo = { ...pendingSwapInfo, itemId }
+    // DEVELOPER: for this reason we don't use multicall
+    const pendingSwapInfo = await bridgeContract.getPendingSwapInfo(itemId)
+    const pendingSwapType = pendingSwapInfo.swapType
+    let swapType
+    if (pendingSwapType === BridgePendingSwapTypes.TokenToSynth) {
+      swapType = SWAP_TYPES.TOKEN_TO_SYNTH
+    } else if (pendingSwapType === BridgePendingSwapTypes.SynthToToken) {
+      swapType = SWAP_TYPES.SYNTH_TO_TOKEN
+    } else if (pendingSwapType === BridgePendingSwapTypes.TokenToToken) {
+      swapType = SWAP_TYPES.TOKEN_TO_TOKEN
+    } else {
+      swapType = SWAP_TYPES.INVALID
+    }
+    const synthTokenFrom = getTokenByAddress(
+      pendingSwapInfo.synth,
+      chainId,
+    ) as Token
+    const tokenTo = getTokenByAddress(pendingSwapInfo.tokenTo, chainId) as Token
+    const settleableAtTimestamp = new Date(
+      (timestampInSeconds + parseInt(pendingSwapInfo.secsLeft.toString())) * // add event block timestamp + secsLeft
+        1000, // convert to ms
+    )
+    result = {
+      swapType,
+      settleableAtTimestamp,
+      secondsRemaining: Math.ceil(
+        (Date.now() - settleableAtTimestamp.getTime()) / 1000,
+      ),
+      synthBalance: pendingSwapInfo.synthBalance,
+      itemId,
+      synthTokenFrom: synthTokenFrom,
+      tokenTo: tokenTo,
+    }
   } catch {
     // do nothing because this is probably okay
   }
-  return pendingSwapInfo
+  return result
 }
 
 export default usePendingSwapData

--- a/src/hooks/usePendingSwapData.ts
+++ b/src/hooks/usePendingSwapData.ts
@@ -118,7 +118,7 @@ const usePendingSwapData = (): PendingSwap[] => {
     return () => {
       clearInterval(timer)
     }
-  }, [])
+  }, [library])
   const pendingSwapEventListener = useCallback(
     (...listenerArgs) => {
       const event = listenerArgs[listenerArgs.length - 1] as Event

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -11,6 +11,7 @@ import { Route, Switch } from "react-router-dom"
 
 import { AppDispatch } from "../state"
 import Deposit from "./Deposit"
+import PendingSwapsProvider from "../providers/PendingSwapsProvider"
 import Pools from "./Pools"
 import Risk from "./Risk"
 import Swap from "./Swap"
@@ -29,53 +30,55 @@ export default function App(): ReactElement {
       <Web3ReactManager>
         <GasAndTokenPrices>
           <ToastsProvider>
-            <Switch>
-              <Route exact path="/" component={Swap} />
-              <Route exact path="/pools" component={Pools} />
-              <Route
-                exact
-                path="/pools/usd/deposit"
-                render={(props) => (
-                  <Deposit {...props} poolName={STABLECOIN_POOL_NAME} />
-                )}
-              />
-              <Route
-                exact
-                path="/pools/btc/deposit"
-                render={(props) => (
-                  <Deposit {...props} poolName={BTC_POOL_NAME} />
-                )}
-              />
-              <Route
-                exact
-                path="/pools/veth2/deposit"
-                render={(props) => (
-                  <Deposit {...props} poolName={VETH2_POOL_NAME} />
-                )}
-              />
-              <Route
-                exact
-                path="/pools/btc/withdraw"
-                render={(props) => (
-                  <Withdraw {...props} poolName={BTC_POOL_NAME} />
-                )}
-              />
-              <Route
-                exact
-                path="/pools/usd/withdraw"
-                render={(props) => (
-                  <Withdraw {...props} poolName={STABLECOIN_POOL_NAME} />
-                )}
-              />
-              <Route
-                exact
-                path="/pools/veth2/withdraw"
-                render={(props) => (
-                  <Withdraw {...props} poolName={VETH2_POOL_NAME} />
-                )}
-              />
-              <Route exact path="/risk" component={Risk} />
-            </Switch>
+            <PendingSwapsProvider>
+              <Switch>
+                <Route exact path="/" component={Swap} />
+                <Route exact path="/pools" component={Pools} />
+                <Route
+                  exact
+                  path="/pools/usd/deposit"
+                  render={(props) => (
+                    <Deposit {...props} poolName={STABLECOIN_POOL_NAME} />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/pools/btc/deposit"
+                  render={(props) => (
+                    <Deposit {...props} poolName={BTC_POOL_NAME} />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/pools/veth2/deposit"
+                  render={(props) => (
+                    <Deposit {...props} poolName={VETH2_POOL_NAME} />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/pools/btc/withdraw"
+                  render={(props) => (
+                    <Withdraw {...props} poolName={BTC_POOL_NAME} />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/pools/usd/withdraw"
+                  render={(props) => (
+                    <Withdraw {...props} poolName={STABLECOIN_POOL_NAME} />
+                  )}
+                />
+                <Route
+                  exact
+                  path="/pools/veth2/withdraw"
+                  render={(props) => (
+                    <Withdraw {...props} poolName={VETH2_POOL_NAME} />
+                  )}
+                />
+                <Route exact path="/risk" component={Risk} />
+              </Switch>
+            </PendingSwapsProvider>
           </ToastsProvider>
         </GasAndTokenPrices>
       </Web3ReactManager>

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -528,7 +528,7 @@ function Swap(): ReactElement {
 
   return (
     <SwapPage
-      pendingSwapData={pendingSwapData}
+      pendingSwaps={pendingSwapData}
       tokenOptions={tokenOptions}
       exchangeRateInfo={{
         pair: `${formState.from.symbol}/${formState.to.symbol}`,

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -31,6 +31,7 @@ import { debounce } from "lodash"
 import { formatGasToString } from "../utils/gas"
 import { useActiveWeb3React } from "../hooks"
 import { useApproveAndSwap } from "../hooks/useApproveAndSwap"
+import usePendingSwapData from "../hooks/usePendingSwapData"
 import { usePoolTokenBalances } from "../state/wallet/hooks"
 import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
@@ -91,6 +92,7 @@ function Swap(): ReactElement {
   const tokenBalances = usePoolTokenBalances()
   const bridgeContract = useBridgeContract()
   const calculateSwapPairs = useCalculateSwapPairs()
+  const pendingSwapData = usePendingSwapData()
   const { tokenPricesUSD, gasStandard, gasFast, gasInstant } = useSelector(
     (state: AppState) => state.application,
   )
@@ -526,6 +528,7 @@ function Swap(): ReactElement {
 
   return (
     <SwapPage
+      pendingSwapData={pendingSwapData}
       tokenOptions={tokenOptions}
       exchangeRateInfo={{
         pair: `${formState.from.symbol}/${formState.to.symbol}`,

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -8,6 +8,7 @@ import {
 import React, {
   ReactElement,
   useCallback,
+  useContext,
   useEffect,
   useMemo,
   useState,
@@ -23,6 +24,7 @@ import { useBridgeContract, useSwapContract } from "../hooks/useContract"
 
 import { AppState } from "../state/index"
 import { BigNumber } from "@ethersproject/bignumber"
+import { PendingSwapsContext } from "../providers/PendingSwapsProvider"
 import SwapPage from "../components/SwapPage"
 import { Zero } from "@ethersproject/constants"
 import { calculateGasEstimate } from "../utils/gasEstimate"
@@ -31,7 +33,6 @@ import { debounce } from "lodash"
 import { formatGasToString } from "../utils/gas"
 import { useActiveWeb3React } from "../hooks"
 import { useApproveAndSwap } from "../hooks/useApproveAndSwap"
-import usePendingSwapData from "../hooks/usePendingSwapData"
 import { usePoolTokenBalances } from "../state/wallet/hooks"
 import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
@@ -92,7 +93,7 @@ function Swap(): ReactElement {
   const tokenBalances = usePoolTokenBalances()
   const bridgeContract = useBridgeContract()
   const calculateSwapPairs = useCalculateSwapPairs()
-  const pendingSwapData = usePendingSwapData()
+  const pendingSwapData = useContext(PendingSwapsContext)
   const { tokenPricesUSD, gasStandard, gasFast, gasInstant } = useSelector(
     (state: AppState) => state.application,
   )

--- a/src/providers/PendingSwapsProvider.tsx
+++ b/src/providers/PendingSwapsProvider.tsx
@@ -1,0 +1,16 @@
+import React, { ReactElement } from "react"
+import usePendingSwapData, { PendingSwap } from "../hooks/usePendingSwapData"
+
+export const PendingSwapsContext = React.createContext<PendingSwap[]>([])
+
+export default function PendingSwapsProvider({
+  children,
+}: React.PropsWithChildren<unknown>): ReactElement {
+  const pendingSwaps = usePendingSwapData()
+
+  return (
+    <PendingSwapsContext.Provider value={pendingSwaps}>
+      {children}
+    </PendingSwapsContext.Provider>
+  )
+}

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -1,7 +1,23 @@
-import { calculateExchangeRate, commify, intersection } from "../index"
+import {
+  calculateExchangeRate,
+  commify,
+  getTokenByAddress,
+  intersection,
+} from "../index"
 
+import { TOKENS_MAP } from "../../constants/index"
 import { Zero } from "@ethersproject/constants"
 import { parseUnits } from "@ethersproject/units"
+
+describe("getTokenByAddress", () => {
+  it("correctly fetches a token", () => {
+    const chainId = 1
+    const target = TOKENS_MAP["sBTC"]
+    expect(getTokenByAddress(target.addresses[chainId], chainId)).toEqual(
+      target,
+    )
+  })
+})
 
 describe("intersection", () => {
   it("correctly intersects two sets", () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -141,7 +141,9 @@ export function getTokenByAddress(
 ): Token | null {
   return (
     Object.values(TOKENS_MAP).find(
-      ({ addresses }) => address === addresses[chainId],
+      ({ addresses }) =>
+        addresses[chainId] &&
+        address.toLowerCase() === addresses[chainId].toLowerCase(),
     ) || null
   )
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,4 @@
+import { ChainId, TOKENS_MAP, Token } from "../constants"
 import { JsonRpcSigner, Web3Provider } from "@ethersproject/providers"
 
 import { AddressZero } from "@ethersproject/constants"
@@ -132,4 +133,15 @@ export function commify(str: string): string {
 
 export function intersection<T>(set1: Set<T>, set2: Set<T>): Set<T> {
   return new Set([...set1].filter((item) => set2.has(item)))
+}
+
+export function getTokenByAddress(
+  address: string,
+  chainId: ChainId,
+): Token | null {
+  return (
+    Object.values(TOKENS_MAP).find(
+      ({ addresses }) => address === addresses[chainId],
+    ) || null
+  )
 }


### PR DESCRIPTION
Creates `usePendingSwapData.ts` hook which fetches existing virtual swaps from event logs on mount, and also attaches listeners for new virtual swap actions. Also adds the basic UI of showing that there are pendingSwaps.

<img width="618" alt="Screen Shot 2021-05-28 at 12 06 15 PM" src="https://user-images.githubusercontent.com/7607886/120015207-12c5c680-bfb1-11eb-8c56-47d86a143ef2.png">


