### PR TITLE
Add types for ethcall

### DIFF
--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -1,9 +1,10 @@
 import { BLOCK_TIME, ChainId, TOKENS_MAP } from "../../constants"
 import { Contract, Provider } from "ethcall"
+import { MulticallContract, MulticallProvider } from "../../types/ethcall"
 
 import { BigNumber } from "@ethersproject/bignumber"
-import { Call } from "ethcall/lib/call"
 import ERC20_ABI from "../../constants/abis/erc20.json"
+import { Erc20 } from "../../../types/ethers-contracts/Erc20"
 import { useActiveWeb3React } from "../../hooks"
 import usePoller from "../../hooks/usePoller"
 import { useState } from "react"
@@ -12,11 +13,11 @@ export function usePoolTokenBalances(): { [token: string]: BigNumber } | null {
   const { account, chainId, library } = useActiveWeb3React()
   const [balances, setBalances] = useState<{ [token: string]: BigNumber }>({})
 
-  const ethcallProvider = new Provider()
+  const ethcallProvider = new Provider() as MulticallProvider
 
   usePoller((): void => {
     async function pollBalances(): Promise<void> {
-      if (!library || !chainId) return
+      if (!library || !chainId || !account) return
 
       await ethcallProvider.init(library)
       // override the contract address when using hardhat
@@ -27,13 +28,14 @@ export function usePoolTokenBalances(): { [token: string]: BigNumber } | null {
 
       const tokens = Object.values(TOKENS_MAP)
       const balanceCalls = tokens
-        .map((t) => new Contract(t.addresses[chainId], ERC20_ABI))
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        .map((c): Call => c.balanceOf(account) as Call)
-      const balances = (await ethcallProvider.all(
-        balanceCalls,
-        {},
-      )) as BigNumber[]
+        .map((t) => {
+          return new Contract(
+            t.addresses[chainId],
+            ERC20_ABI,
+          ) as MulticallContract<Erc20>
+        })
+        .map((c) => c.balanceOf(account))
+      const balances = await ethcallProvider.all(balanceCalls, {})
 
       setBalances(
         tokens.reduce(

--- a/src/types/ethcall.d.ts
+++ b/src/types/ethcall.d.ts
@@ -1,0 +1,23 @@
+import { Call, Contract, Provider } from "ethcall"
+
+export class MulticallCall<Inputs, Outputs> extends Call {
+  inputs: Inputs
+  outputs: Outputs
+}
+
+export type MulticallContract<ContractType> = {
+  [Fn in keyof ContractType["functions"]]: (
+    ...args: Parameters<ContractType[Fn]>
+  ) => MulticallCall<
+    Parameters<ContractType[Fn]>,
+    ReturnType<ContractType[Fn]> extends Promise<infer V>
+      ? V // if ReturnType is a Promise, unwrap it
+      : ReturnType<ContractType[Fn]>
+  >
+} &
+  Contract
+export class MulticallProvider extends Provider {
+  // TODO: this only support return values of the same type rather than mixed
+  // TS can't infer tuple types :(
+  all<O>(calls: MulticallCall<I, O>[], overrides: CallOverrides): Promise<O[]>
+}


### PR DESCRIPTION
Create an internal type for the `ethcall` library (TS doesn't let you overwrite existing declarations, otherwise I would have declared this type on the library directly) which infers the return type of calls from the `typechain` contract types.