### PR TITLE
Calculate Swap Pairs

### DIFF
--- a/src/hooks/__tests__/useCalculateSwapPairs.ts
+++ b/src/hooks/__tests__/useCalculateSwapPairs.ts
@@ -1,0 +1,205 @@
+import { Pool, SWAP_TYPES, Token } from "../../constants/index"
+
+import { __test__ } from "../useCalculateSwapPairs"
+
+const { getTradingPairsForToken } = __test__
+
+const createTestToken = (name: string, isSynth?: boolean) => {
+  return new Token({ 1: "", 31337: "" }, 0, name, "", name, "", !!isSynth)
+}
+const createTestPool = (name: string, tokens: Token[]) => {
+  return {
+    name: name,
+    lpToken: createTestToken(`${name} LPToken`),
+    poolTokens: tokens,
+    isSynthetic: tokens.some(({ isSynthetic }) => isSynthetic),
+  }
+}
+describe("getTradingPairsForToken", () => {
+  const tokenA = createTestToken("tokenA")
+  const tokenB = createTestToken("tokenB")
+  const tokenC = createTestToken("tokenC")
+  const tokenD = createTestToken("tokenD")
+  const tokenE = createTestToken("tokenESynth", true)
+  const tokenF = createTestToken("tokenFSynth", true)
+  const tokenG = createTestToken("tokenG")
+
+  const pool1 = createTestPool("NonSynth AB", [tokenA, tokenB])
+  const pool2 = createTestPool("Synth CDE", [tokenC, tokenD, tokenE])
+  const pool3 = createTestPool("Synth DFG", [tokenD, tokenF, tokenG])
+
+  const allTokens = [tokenA, tokenB, tokenC, tokenD, tokenE, tokenF, tokenG]
+  const allPools = [pool1, pool2, pool3]
+
+  const tokensMap = allTokens.reduce(
+    (acc, t) => ({ ...acc, [t.symbol]: t }),
+    {} as { [symbol: string]: Token },
+  )
+  const poolsMap = allPools.reduce(
+    (acc, p) => ({ ...acc, [p.name]: p }),
+    {} as { [symbol: string]: Pool },
+  )
+  const tokensToPoolsMap = {
+    [tokenA.symbol]: [pool1.name],
+    [tokenB.symbol]: [pool1.name],
+    [tokenC.symbol]: [pool2.name],
+    [tokenD.symbol]: [pool2.name, pool3.name],
+    [tokenE.symbol]: [pool2.name],
+    [tokenF.symbol]: [pool3.name],
+    [tokenG.symbol]: [pool3.name],
+  }
+  it("Tokens can't swap with themselves", () => {
+    const pairs = getTradingPairsForToken(
+      tokensMap,
+      poolsMap,
+      tokensToPoolsMap,
+      tokenA,
+    )
+    const selfPair = pairs.find(
+      (swapData) => swapData.from.symbol === swapData.to.symbol,
+    )
+    expect(selfPair).toEqual({
+      type: SWAP_TYPES.INVALID,
+      from: {
+        symbol: tokenA.symbol,
+        poolName: undefined,
+        tokenIndex: undefined,
+      },
+      to: {
+        symbol: tokenA.symbol,
+        poolName: undefined,
+        tokenIndex: undefined,
+      },
+      route: [],
+    })
+  })
+
+  it("Tokens in non-synth pools can only swap with each other", () => {
+    const pairs = getTradingPairsForToken(
+      tokensMap,
+      poolsMap,
+      tokensToPoolsMap,
+      tokenA,
+    )
+    expect(pairs).toContainEqual({
+      type: SWAP_TYPES.DIRECT,
+      from: {
+        symbol: tokenA.symbol,
+        poolName: pool1.name,
+        tokenIndex: pool1.poolTokens.indexOf(tokenA),
+      },
+      to: {
+        symbol: tokenB.symbol,
+        poolName: pool1.name,
+        tokenIndex: pool1.poolTokens.indexOf(tokenB),
+      },
+      route: [tokenA.symbol, tokenB.symbol],
+    })
+    for (const swapData of pairs) {
+      const { type, to } = swapData
+      if (to.poolName !== pool1.name) {
+        expect(type).toEqual(SWAP_TYPES.INVALID)
+      }
+    }
+  })
+
+  it("Synth tokens can swap with any other synth token", () => {
+    const pairs = getTradingPairsForToken(
+      tokensMap,
+      poolsMap,
+      tokensToPoolsMap,
+      tokenE,
+    )
+    expect(tokenE.isSynthetic).toBeTruthy()
+    expect(tokenF.isSynthetic).toBeTruthy()
+    expect(pairs).toContainEqual({
+      type: SWAP_TYPES.SYNTH_TO_SYNTH,
+      from: {
+        symbol: tokenE.symbol,
+        poolName: pool2.name,
+        tokenIndex: pool2.poolTokens.indexOf(tokenE),
+      },
+      to: {
+        symbol: tokenF.symbol,
+        poolName: pool3.name,
+        tokenIndex: pool3.poolTokens.indexOf(tokenF),
+      },
+      route: [tokenE.symbol, tokenF.symbol],
+    })
+  })
+
+  it("A synth token can swap with a nonSynth token in a synth pool", () => {
+    const pairs = getTradingPairsForToken(
+      tokensMap,
+      poolsMap,
+      tokensToPoolsMap,
+      tokenF,
+    )
+    expect(tokenF.isSynthetic).toBeTruthy()
+    expect(tokenC.isSynthetic).toBeFalsy()
+    expect(pairs).toContainEqual({
+      type: SWAP_TYPES.SYNTH_TO_TOKEN,
+      from: {
+        symbol: tokenF.symbol,
+        poolName: pool3.name,
+        tokenIndex: pool3.poolTokens.indexOf(tokenF),
+      },
+      to: {
+        symbol: tokenC.symbol,
+        poolName: pool2.name,
+        tokenIndex: pool2.poolTokens.indexOf(tokenC),
+      },
+      route: [tokenF.symbol, tokenE.symbol, tokenC.symbol],
+    })
+  })
+
+  it("A nonSynth token in a synth pool can swap with another nonSynth token in a different synth pool", () => {
+    const pairs = getTradingPairsForToken(
+      tokensMap,
+      poolsMap,
+      tokensToPoolsMap,
+      tokenC,
+    )
+    expect(tokenC.isSynthetic).toBeFalsy()
+    expect(tokenG.isSynthetic).toBeFalsy()
+    expect(pairs).toContainEqual({
+      type: SWAP_TYPES.TOKEN_TO_TOKEN,
+      from: {
+        symbol: tokenC.symbol,
+        poolName: pool2.name,
+        tokenIndex: pool2.poolTokens.indexOf(tokenC),
+      },
+      to: {
+        symbol: tokenG.symbol,
+        poolName: pool3.name,
+        tokenIndex: pool3.poolTokens.indexOf(tokenG),
+      },
+      route: [tokenC.symbol, tokenE.symbol, tokenF.symbol, tokenG.symbol],
+    })
+  })
+
+  it("A nonSynth token in a synth pool can swap with a synth token in another pool", () => {
+    const pairs = getTradingPairsForToken(
+      tokensMap,
+      poolsMap,
+      tokensToPoolsMap,
+      tokenC,
+    )
+    expect(tokenC.isSynthetic).toBeFalsy()
+    expect(tokenF.isSynthetic).toBeTruthy()
+    expect(pairs).toContainEqual({
+      type: SWAP_TYPES.TOKEN_TO_SYNTH,
+      from: {
+        symbol: tokenC.symbol,
+        poolName: pool2.name,
+        tokenIndex: pool2.poolTokens.indexOf(tokenC),
+      },
+      to: {
+        symbol: tokenF.symbol,
+        poolName: pool3.name,
+        tokenIndex: pool3.poolTokens.indexOf(tokenF),
+      },
+      route: [tokenC.symbol, tokenE.symbol, tokenF.symbol],
+    })
+  })
+})

--- a/src/hooks/useCalculateSwapPairs.ts
+++ b/src/hooks/useCalculateSwapPairs.ts
@@ -138,12 +138,13 @@ function getTradingPairsForToken(
       const middleSynth = destinationPool.poolTokens.find(
         ({ isSynthetic }) => isSynthetic,
       )
-      if (!middleSynth) return swapData
-      swapData = {
-        type: SWAP_TYPES.SYNTH_TO_TOKEN,
-        from: buildSwapSideData(originToken, originPool),
-        to: buildSwapSideData(token, destinationPool),
-        route: [originToken.symbol, middleSynth.symbol, token.symbol],
+      if (middleSynth) {
+        swapData = {
+          type: SWAP_TYPES.SYNTH_TO_TOKEN,
+          from: buildSwapSideData(originToken, originPool),
+          to: buildSwapSideData(token, destinationPool),
+          route: [originToken.symbol, middleSynth.symbol, token.symbol],
+        }
       }
     }
 

--- a/src/hooks/useCalculateSwapPairs.ts
+++ b/src/hooks/useCalculateSwapPairs.ts
@@ -1,0 +1,213 @@
+import {
+  POOLS_MAP,
+  Pool,
+  PoolsMap,
+  SWAP_TYPES,
+  TOKENS_MAP,
+  TOKEN_TO_POOLS_MAP,
+  Token,
+  TokenToPoolsMap,
+  TokensMap,
+} from "../constants/index"
+
+import { intersection } from "../utils/index"
+import { useState } from "react"
+
+type TokenToSwapDataMap = { [symbol: string]: SwapData[] }
+export function useCalculateSwapPairs(): (token: Token) => SwapData[] {
+  const [pairCache, setPairCache] = useState<TokenToSwapDataMap>({})
+
+  return function calculateSwapPairs(token: Token): SwapData[] {
+    const cacheHit = pairCache[token.symbol]
+    if (cacheHit) return cacheHit
+    const swapPairs = getTradingPairsForToken(
+      TOKENS_MAP,
+      POOLS_MAP,
+      TOKEN_TO_POOLS_MAP,
+      token,
+    )
+    setPairCache((prevState) => ({ ...prevState, [token.symbol]: swapPairs }))
+    return swapPairs
+  }
+}
+
+function buildSwapSideData(token: Token): SwapSide
+function buildSwapSideData(token: Token, pool: Pool): Required<SwapSide>
+function buildSwapSideData(
+  token: Token,
+  pool?: Pool,
+): Required<SwapSide> | SwapSide {
+  return {
+    symbol: token.symbol,
+    poolName: pool?.name,
+    tokenIndex: pool?.poolTokens.findIndex((t) => t === token),
+  }
+}
+
+type SwapSide = {
+  symbol: string
+  poolName?: string
+  tokenIndex?: number
+}
+
+type SwapData =
+  | {
+      from: Required<SwapSide>
+      to: Required<SwapSide>
+      type: Exclude<SWAP_TYPES, SWAP_TYPES.INVALID>
+      route: string[]
+    }
+  | {
+      from: SwapSide
+      to: SwapSide
+      type: SWAP_TYPES.INVALID
+      route: string[]
+    }
+
+function getTradingPairsForToken(
+  tokensMap: TokensMap,
+  poolsMap: PoolsMap,
+  tokenToPoolsMap: TokenToPoolsMap,
+  originToken: Token,
+): SwapData[] {
+  const allTokens = Object.values(tokensMap)
+  const synthPoolsSet = new Set(
+    Object.values(poolsMap).filter(({ isSynthetic }) => isSynthetic),
+  )
+  const originTokenPoolsSet = new Set(
+    tokenToPoolsMap[originToken.symbol].map((poolName) => poolsMap[poolName]),
+  )
+  const originPoolsSynthSet = intersection(synthPoolsSet, originTokenPoolsSet)
+  const tokenToSwapDataMap: { [symbol: string]: SwapData } = {} // object is used for deduping
+
+  allTokens.forEach((token) => {
+    // Base Case: Invalid trade, eg token with itself
+    let swapData: SwapData = {
+      from: buildSwapSideData(originToken),
+      to: buildSwapSideData(token),
+      type: SWAP_TYPES.INVALID,
+      route: [],
+    }
+    const tokenPoolsSet = new Set(
+      tokenToPoolsMap[token.symbol].map((poolName) => poolsMap[poolName]),
+    )
+    const tokenPoolsSynthSet = intersection(synthPoolsSet, tokenPoolsSet)
+    const sharedPoolsSet = intersection(originTokenPoolsSet, tokenPoolsSet)
+
+    /**
+     * sToken = synth, Token = nonsynth
+     * sPool = synth, Pool = nonsynth
+     * sPool(TokenA) <> sTokenB = nonsynth token in synth pool swapping with synth token
+     */
+
+    // Case 1: TokenA <> TokenA
+    if (originToken === token) {
+      // fall through to default "invalid" swapData
+    }
+    // Case 2: poolA(TokenA) <> poolA(TokenB)
+    else if (sharedPoolsSet.size > 0) {
+      const tradePool = [...sharedPoolsSet][0]
+      swapData = {
+        type: SWAP_TYPES.DIRECT,
+        from: buildSwapSideData(originToken, tradePool),
+        to: buildSwapSideData(token, tradePool),
+        route: [originToken.symbol, token.symbol],
+      }
+    }
+
+    // Case 3: sTokenA <> sTokenB
+    else if (originToken.isSynthetic && token.isSynthetic) {
+      const originPool = [...originTokenPoolsSet][0]
+      const destinationPool = [...tokenPoolsSet][0]
+      swapData = {
+        type: SWAP_TYPES.SYNTH_TO_SYNTH,
+        from: buildSwapSideData(originToken, originPool),
+        to: buildSwapSideData(token, destinationPool),
+        route: [originToken.symbol, token.symbol],
+      }
+    }
+
+    // Case 4: sTokenA <> sPool(TokenB)
+    else if (
+      originToken.isSynthetic &&
+      !token.isSynthetic &&
+      tokenPoolsSynthSet.size > 0
+    ) {
+      const originPool = [...originTokenPoolsSet][0]
+      const destinationPool = [...tokenPoolsSynthSet][0]
+      const middleSynth = destinationPool.poolTokens.find(
+        ({ isSynthetic }) => isSynthetic,
+      )
+      if (!middleSynth) return swapData
+      swapData = {
+        type: SWAP_TYPES.SYNTH_TO_TOKEN,
+        from: buildSwapSideData(originToken, originPool),
+        to: buildSwapSideData(token, destinationPool),
+        route: [originToken.symbol, middleSynth.symbol, token.symbol],
+      }
+    }
+
+    // Case 5: sPoolA(TokenA) <> sPoolB(TokenB)
+    else if (
+      !originToken.isSynthetic &&
+      originPoolsSynthSet.size > 0 &&
+      !token.isSynthetic &&
+      tokenPoolsSynthSet.size > 0
+    ) {
+      const originPool = [...originPoolsSynthSet][0]
+      const destinationPool = [...tokenPoolsSynthSet][0]
+      const originSynth = originPool.poolTokens.find(
+        ({ isSynthetic }) => isSynthetic,
+      )
+      const destinationSynth = destinationPool.poolTokens.find(
+        ({ isSynthetic }) => isSynthetic,
+      )
+      if (originSynth && destinationSynth) {
+        swapData = {
+          type: SWAP_TYPES.TOKEN_TO_TOKEN,
+          from: buildSwapSideData(originToken, originPool),
+          to: buildSwapSideData(token, destinationPool),
+          route: [
+            originToken.symbol,
+            originSynth.symbol,
+            destinationSynth.symbol,
+            token.symbol,
+          ],
+        }
+      }
+    }
+
+    // Case 6: sPool(TokenA) <> sTokenB
+    else if (
+      !originToken.isSynthetic &&
+      originPoolsSynthSet.size > 0 &&
+      token.isSynthetic
+    ) {
+      const originPool = [...originPoolsSynthSet][0]
+      const destinationPool = [...tokenPoolsSet][0]
+      const middleSynth = originPool.poolTokens.find(
+        ({ isSynthetic }) => isSynthetic,
+      )
+      if (middleSynth) {
+        swapData = {
+          type: SWAP_TYPES.TOKEN_TO_SYNTH,
+          from: buildSwapSideData(originToken, originPool),
+          to: buildSwapSideData(token, destinationPool),
+          route: [originToken.symbol, middleSynth.symbol, token.symbol],
+        }
+      }
+    }
+
+    // use this swap only if we haven't already calculated a better swap for the pair
+    const existingTokenSwapData = tokenToSwapDataMap[token.symbol]
+    if (!existingTokenSwapData || existingTokenSwapData.type > swapData.type) {
+      tokenToSwapDataMap[token.symbol] = swapData
+    }
+  })
+
+  return Object.values(tokenToSwapDataMap)
+}
+
+export const __test__ = {
+  getTradingPairsForToken,
+}

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -1,7 +1,15 @@
-import { calculateExchangeRate, commify } from "../index"
+import { calculateExchangeRate, commify, intersection } from "../index"
 
 import { Zero } from "@ethersproject/constants"
 import { parseUnits } from "@ethersproject/units"
+
+describe("intersection", () => {
+  it("correctly intersects two sets", () => {
+    const setA = new Set([1, 2, 3, 4])
+    const setB = new Set([3, 4, 5, 6])
+    expect(intersection(setA, setB)).toEqual(new Set([3, 4]))
+  })
+})
 
 describe("calculateExchangeRate", () => {
   it("correctly calculates value for 0 input", () => {

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -129,3 +129,7 @@ export function commify(str: string): string {
   const commifiedA = commaAArr.join("")
   return partB === undefined ? commifiedA : `${commifiedA}.${partB}`
 }
+
+export function intersection<T>(set1: Set<T>, set2: Set<T>): Set<T> {
+  return new Set([...set1].filter((item) => set2.has(item)))
+}


### PR DESCRIPTION
This PR creates the initial logic for calculating if and how one token can be swapped with another. The swap types are as follows:
```
export enum SWAP_TYPES {
  DIRECT, // route length 2
  SYNTH_TO_SYNTH, // route length 2
  SYNTH_TO_TOKEN, // route length 3
  TOKEN_TO_SYNTH, // route length 3
  TOKEN_TO_TOKEN, // route length 4
  INVALID,
}
```
This function also returns the route for display, as well as some data that will be required for contract calls (pool, token index, etc)