### PR TITLE
SharedStake APY

### DIFF
--- a/src/components/DepositPage.tsx
+++ b/src/components/DepositPage.tsx
@@ -72,7 +72,7 @@ const DepositPage = (props: Props): ReactElement => {
   return (
     <div className="deposit">
       <TopMenu activeTab={"deposit"} />
-      {poolData?.keepApr.gt(Zero) && myShareData?.lpTokenBalance.gt(0) && (
+      {poolData?.aprs?.keep.gt(Zero) && myShareData?.lpTokenBalance.gt(0) && (
         <LPStakingBanner
           stakingLink={"https://dashboard.keep.network/liquidity"}
         />
@@ -106,7 +106,7 @@ const DepositPage = (props: Props): ReactElement => {
             ))}
             <div className={classNames("transactionInfoContainer", "show")}>
               <div className="transactionInfo">
-                {poolData?.keepApr.gt(Zero) && (
+                {poolData?.aprs?.keep.gt(Zero) && (
                   <div className="transactionInfoItem">
                     <a
                       href="https://docs.saddle.finance/faq#what-are-saddles-liquidity-provider-rewards"
@@ -116,7 +116,21 @@ const DepositPage = (props: Props): ReactElement => {
                       <span>{`KEEP APR:`}</span>
                     </a>{" "}
                     <span className="value">
-                      {formatBNToPercentString(poolData.keepApr, 18)}
+                      {formatBNToPercentString(poolData.aprs.keep, 18)}
+                    </span>
+                  </div>
+                )}
+                {poolData?.aprs?.sharedStake.gt(Zero) && (
+                  <div className="transactionInfoItem">
+                    <a
+                      href="https://docs.saddle.finance/faq#what-are-saddles-liquidity-provider-rewards"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <span>{`SGT APR:`}</span>
+                    </a>{" "}
+                    <span className="value">
+                      {formatBNToPercentString(poolData.aprs.sharedStake, 18)}
                     </span>
                   </div>
                 )}

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -26,7 +26,10 @@ function PoolOverview({
   const formattedData = {
     name: poolData.name,
     reserve: `$${commify(formatBNToString(poolData.reserve, 18, 2))}`,
-    apr: formatBNToPercentString(poolData.keepApr, 18),
+    aprs: {
+      keep: formatBNToPercentString(poolData.aprs.keep, 18),
+      sharedStake: formatBNToPercentString(poolData.aprs.sharedStake, 18),
+    },
     userBalanceUSD: `$${commify(
       formatBNToString(userShareData?.usdBalance || Zero, 18, 2),
     )}`,
@@ -58,16 +61,29 @@ function PoolOverview({
           </div>
 
           <div className="right">
-            {poolData?.keepApr.gt(Zero) && (
+            {poolData?.aprs.keep.gt(Zero) && (
               <div className="Apr">
                 <span className="label">KEEP APR</span>
                 <span
                   className={
-                    classNames({ plus: formattedData.apr }) +
-                    classNames({ minus: !formattedData.apr })
+                    classNames({ plus: formattedData.aprs.keep }) +
+                    classNames({ minus: !formattedData.aprs.keep })
                   }
                 >
-                  {formattedData.apr}
+                  {formattedData.aprs.keep}
+                </span>
+              </div>
+            )}
+            {poolData?.aprs.sharedStake.gt(Zero) && (
+              <div className="Apr">
+                <span className="label">SGT APR</span>
+                <span
+                  className={
+                    classNames({ plus: formattedData.aprs.sharedStake }) +
+                    classNames({ minus: !formattedData.aprs.sharedStake })
+                  }
+                >
+                  {formattedData.aprs.sharedStake}
                 </span>
               </div>
             )}

--- a/src/constants/abis/sharedStakeStakingRewards.json
+++ b/src/constants/abis/sharedStakeStakingRewards.json
@@ -1,0 +1,504 @@
+[
+  {
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" },
+      {
+        "internalType": "address",
+        "name": "_rewardsDistribution",
+        "type": "address"
+      },
+      { "internalType": "address", "name": "_rewardsToken", "type": "address" },
+      { "internalType": "address", "name": "_stakingToken", "type": "address" },
+      {
+        "internalType": "uint256",
+        "name": "_rewardsDuration",
+        "type": "uint256"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldOwner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnerNominated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "isPaused",
+        "type": "bool"
+      }
+    ],
+    "name": "PauseChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "token",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Recovered",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reward",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardPaid",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "RewardsDurationUpdated",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Staked",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdrawn",
+    "type": "event"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "FASTGAS",
+    "outputs": [
+      {
+        "internalType": "contract IChainLinkFeed",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "acceptOwnership",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "balanceOf",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [
+      { "internalType": "address", "name": "account", "type": "address" }
+    ],
+    "name": "earned",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "exit",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getFastGas",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [],
+    "name": "getReward",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "getRewardForDuration",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastPauseTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastTimeRewardApplicable",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "lastUpdateTime",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "_owner", "type": "address" }
+    ],
+    "name": "nominateNewOwner",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "nominatedOwner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "reward", "type": "uint256" },
+      { "internalType": "address", "name": "rewardHolder", "type": "address" }
+    ],
+    "name": "notifyRewardAmount",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "owner",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "paused",
+    "outputs": [{ "internalType": "bool", "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "periodFinish",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "address", "name": "tokenAddress", "type": "address" },
+      { "internalType": "uint256", "name": "tokenAmount", "type": "uint256" }
+    ],
+    "name": "recoverERC20",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardPerToken",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardPerTokenStored",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardRate",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "rewards",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardsDistribution",
+    "outputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardsDuration",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "rewardsToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [{ "internalType": "bool", "name": "_paused", "type": "bool" }],
+    "name": "setPaused",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_rewardsDistribution",
+        "type": "address"
+      }
+    ],
+    "name": "setRewardsDistribution",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "_rewardsDuration",
+        "type": "uint256"
+      }
+    ],
+    "name": "setRewardsDuration",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "stake",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "stakingToken",
+    "outputs": [
+      { "internalType": "contract IERC20", "name": "", "type": "address" }
+    ],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "totalSupply",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [{ "internalType": "address", "name": "", "type": "address" }],
+    "name": "userRewardPerTokenPaid",
+    "outputs": [{ "internalType": "uint256", "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "internalType": "uint256", "name": "amount", "type": "uint256" }
+    ],
+    "name": "withdraw",
+    "outputs": [],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -19,83 +19,92 @@ import Web3ReactManager from "../components/Web3ReactManager"
 import Withdraw from "./Withdraw"
 import fetchGasPrices from "../utils/updateGasPrices"
 import fetchTokenPricesUSD from "../utils/updateTokenPrices"
+import { useActiveWeb3React } from "../hooks"
 import { useDispatch } from "react-redux"
 import usePoller from "../hooks/usePoller"
 
 export default function App(): ReactElement {
+  return (
+    <Suspense fallback={null}>
+      <Web3ReactManager>
+        <GasAndTokenPrices>
+          <ToastsProvider>
+            <Switch>
+              <Route exact path="/" component={Swap} />
+              <Route
+                exact
+                path="/deposit"
+                render={(props) => <Pools {...props} action="deposit" />}
+              />
+              <Route
+                exact
+                path="/deposit/usd"
+                render={(props) => (
+                  <Deposit {...props} poolName={STABLECOIN_POOL_NAME} />
+                )}
+              />
+              <Route
+                exact
+                path="/deposit/btc"
+                render={(props) => (
+                  <Deposit {...props} poolName={BTC_POOL_NAME} />
+                )}
+              />
+              <Route
+                exact
+                path="/deposit/veth2"
+                render={(props) => (
+                  <Deposit {...props} poolName={VETH2_POOL_NAME} />
+                )}
+              />
+              <Route
+                exact
+                path="/withdraw"
+                render={(props) => <Pools {...props} action="withdraw" />}
+              />
+              <Route
+                exact
+                path="/withdraw/btc"
+                render={(props) => (
+                  <Withdraw {...props} poolName={BTC_POOL_NAME} />
+                )}
+              />
+              <Route
+                exact
+                path="/withdraw/usd"
+                render={(props) => (
+                  <Withdraw {...props} poolName={STABLECOIN_POOL_NAME} />
+                )}
+              />
+              <Route
+                exact
+                path="/withdraw/veth2"
+                render={(props) => (
+                  <Withdraw {...props} poolName={VETH2_POOL_NAME} />
+                )}
+              />
+              <Route exact path="/risk" component={Risk} />
+            </Switch>
+          </ToastsProvider>
+        </GasAndTokenPrices>
+      </Web3ReactManager>
+    </Suspense>
+  )
+}
+
+function GasAndTokenPrices({
+  children,
+}: React.PropsWithChildren<unknown>): ReactElement {
   const dispatch = useDispatch<AppDispatch>()
+  const { library } = useActiveWeb3React()
 
   const fetchAndUpdateGasPrice = useCallback(() => {
     void fetchGasPrices(dispatch)
   }, [dispatch])
   const fetchAndUpdateTokensPrice = useCallback(() => {
-    fetchTokenPricesUSD(dispatch)
-  }, [dispatch])
+    fetchTokenPricesUSD(dispatch, library)
+  }, [dispatch, library])
   usePoller(fetchAndUpdateGasPrice, BLOCK_TIME)
   usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
-
-  return (
-    <Suspense fallback={null}>
-      <Web3ReactManager>
-        <ToastsProvider>
-          <Switch>
-            <Route exact path="/" component={Swap} />
-            <Route
-              exact
-              path="/deposit"
-              render={(props) => <Pools {...props} action="deposit" />}
-            />
-            <Route
-              exact
-              path="/deposit/usd"
-              render={(props) => (
-                <Deposit {...props} poolName={STABLECOIN_POOL_NAME} />
-              )}
-            />
-            <Route
-              exact
-              path="/deposit/btc"
-              render={(props) => (
-                <Deposit {...props} poolName={BTC_POOL_NAME} />
-              )}
-            />
-            <Route
-              exact
-              path="/deposit/veth2"
-              render={(props) => (
-                <Deposit {...props} poolName={VETH2_POOL_NAME} />
-              )}
-            />
-            <Route
-              exact
-              path="/withdraw"
-              render={(props) => <Pools {...props} action="withdraw" />}
-            />
-            <Route
-              exact
-              path="/withdraw/btc"
-              render={(props) => (
-                <Withdraw {...props} poolName={BTC_POOL_NAME} />
-              )}
-            />
-            <Route
-              exact
-              path="/withdraw/usd"
-              render={(props) => (
-                <Withdraw {...props} poolName={STABLECOIN_POOL_NAME} />
-              )}
-            />
-            <Route
-              exact
-              path="/withdraw/veth2"
-              render={(props) => (
-                <Withdraw {...props} poolName={VETH2_POOL_NAME} />
-              )}
-            />
-            <Route exact path="/risk" component={Risk} />
-          </Switch>
-        </ToastsProvider>
-      </Web3ReactManager>
-    </Suspense>
-  )
+  return <>{children}</>
 }

--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -1,9 +1,10 @@
 import { BLOCK_TIME, ChainId, TOKENS_MAP } from "../../constants"
 import { Contract, Provider } from "ethcall"
+import { MulticallContract, MulticallProvider } from "../../types/ethcall"
 
 import { BigNumber } from "@ethersproject/bignumber"
-import { Call } from "ethcall/lib/call"
 import ERC20_ABI from "../../constants/abis/erc20.json"
+import { Erc20 } from "../../../types/ethers-contracts/Erc20"
 import { useActiveWeb3React } from "../../hooks"
 import usePoller from "../../hooks/usePoller"
 import { useState } from "react"
@@ -12,11 +13,11 @@ export function usePoolTokenBalances(): { [token: string]: BigNumber } | null {
   const { account, chainId, library } = useActiveWeb3React()
   const [balances, setBalances] = useState<{ [token: string]: BigNumber }>({})
 
-  const ethcallProvider = new Provider()
+  const ethcallProvider = new Provider() as MulticallProvider
 
   usePoller((): void => {
     async function pollBalances(): Promise<void> {
-      if (!library || !chainId) return
+      if (!library || !chainId || !account) return
 
       await ethcallProvider.init(library)
       // override the contract address when using hardhat
@@ -27,13 +28,14 @@ export function usePoolTokenBalances(): { [token: string]: BigNumber } | null {
 
       const tokens = Object.values(TOKENS_MAP)
       const balanceCalls = tokens
-        .map((t) => new Contract(t.addresses[chainId], ERC20_ABI))
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-call
-        .map((c): Call => c.balanceOf(account) as Call)
-      const balances = (await ethcallProvider.all(
-        balanceCalls,
-        {},
-      )) as BigNumber[]
+        .map((t) => {
+          return new Contract(
+            t.addresses[chainId],
+            ERC20_ABI,
+          ) as MulticallContract<Erc20>
+        })
+        .map((c) => c.balanceOf(account))
+      const balances = await ethcallProvider.all(balanceCalls, {})
 
       setBalances(
         tokens.reduce(

--- a/src/types/ethcall.d.ts
+++ b/src/types/ethcall.d.ts
@@ -1,0 +1,23 @@
+import { Call, Contract, Provider } from "ethcall"
+
+export class MulticallCall<Inputs, Outputs> extends Call {
+  inputs: Inputs
+  outputs: Outputs
+}
+
+export type MulticallContract<ContractType> = {
+  [Fn in keyof ContractType["functions"]]: (
+    ...args: Parameters<ContractType[Fn]>
+  ) => MulticallCall<
+    Parameters<ContractType[Fn]>,
+    ReturnType<ContractType[Fn]> extends Promise<infer V>
+      ? V // if ReturnType is a Promise, unwrap it
+      : ReturnType<ContractType[Fn]>
+  >
+} &
+  Contract
+export class MulticallProvider extends Provider {
+  // TODO: this only support return values of the same type rather than mixed
+  // TS can't infer tuple types :(
+  all<O>(calls: MulticallCall<I, O>[], overrides: CallOverrides): Promise<O[]>
+}

--- a/src/types/ethcall.d.ts
+++ b/src/types/ethcall.d.ts
@@ -17,7 +17,37 @@ export type MulticallContract<ContractType> = {
 } &
   Contract
 export class MulticallProvider extends Provider {
-  // TODO: this only support return values of the same type rather than mixed
-  // TS can't infer tuple types :(
-  all<O>(calls: MulticallCall<I, O>[], overrides: CallOverrides): Promise<O[]>
+  /**
+   *  TODO: TS can't infer tuple types
+   *  so this huge type supports either arrays of calls with the same return type (eg BigNumber[])
+   *  Or a tuple of up to 4 ditinct calls *as const* (meaning you can use map or push)
+   *  eg `const calls = [getNum(), getStr(), getBN()] as const; await p.all(calls)`
+   *  Want do build a larger tuple of calls? Just add more to this definition.
+   *  */
+  all<A extends MulticallCall>(
+    calls: readonly [A],
+    overrides: CallOverrides,
+  ): Promise<[A["outputs"]]>
+  all<A extends MulticallCall, B extends MulticallCall>(
+    calls: readonly [A, B],
+    overrides: CallOverrides,
+  ): Promise<[A["outputs"], B["outputs"]]>
+  all<
+    A extends MulticallCall,
+    B extends MulticallCall,
+    C extends MulticallCall
+  >(
+    calls: readonly [A, B, C],
+    overrides: CallOverrides,
+  ): Promise<[A["outputs"], B["outputs"], C["outputs"]]>
+  all<
+    A extends MulticallCall,
+    B extends MulticallCall,
+    C extends MulticallCall,
+    D extends MulticallCall
+  >(
+    calls: readonly [A, B, C, D],
+    overrides: CallOverrides,
+  ): Promise<[A["outputs"], B["outputs"], C["outputs"], D["outputs"]]>
+  all<O>(calls: MulticallCall<I, O>[], overrides: CallOverrides): Promise<O[]> // fallthrough to array type
 }


### PR DESCRIPTION
- Calculate veth2 price from the ex-rate between veths & eth. 
- Add sgt pool apy in `usePoolData` hook. 
- Display new apy. 
- Nest tokenPrices under react manager so that the token price calculations have access to a web3 provider

NOTE: Our apy is slightly different from what is shown on the SGT website. I think this a bug in [their code](https://github.com/SharedStake/SharedStake-ui/blob/main/src/utils/veth2.js) where they calculate the veth2 price by calling `swap.calculateSwap(0,1)` which is eth -> weth2, when what I think they want is `(1,0)`. But somebody please double check my math on this as I am no mathlete.

<img width="915" alt="Screen Shot 2021-05-11 at 11 50 15 PM" src="https://user-images.githubusercontent.com/7607886/118065040-1cb0be00-b351-11eb-9e27-610bb25ec305.png">
