### PR TITLE
[VS pt 2] Virtual Swaps & calcSwaps

### DIFF
--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -31,10 +31,7 @@ context("Deposit Flow", () => {
       //     .contains(`Successfully approved spend for ${tokenName}`)
       //     .should("exist")
       // })
-      cy.get("div.toast")
-        .last()
-        .contains("giddyup", { timeout: 10000 })
-        .should("exist")
+      cy.contains("giddyup", { timeout: 10000 }).should("exist")
     })
   }
   ;["BTC", "Stablecoin"].forEach(testPoolDeposit)

--- a/src/components/SearchSelect.module.scss
+++ b/src/components/SearchSelect.module.scss
@@ -88,8 +88,7 @@
 .tagWrapper {
   display: flex;
   align-items: center;
-  > .unavailableTag,
-  .virtualSwapTag {
+  > .unavailableTag, .virtualSwapTag {
     border: 1px solid var(--text-lightest);
     border-radius: 4px;
     padding: 1px 2px;

--- a/src/components/SearchSelect.module.scss
+++ b/src/components/SearchSelect.module.scss
@@ -88,7 +88,8 @@
 .tagWrapper {
   display: flex;
   align-items: center;
-  > .unavailableTag, .virtualSwapTag {
+  > .unavailableTag,
+  .virtualSwapTag {
     border: 1px solid var(--text-lightest);
     border-radius: 4px;
     padding: 1px 2px;

--- a/src/components/SearchSelect.tsx
+++ b/src/components/SearchSelect.tsx
@@ -6,25 +6,17 @@ import React, {
   useState,
 } from "react"
 
-import { BigNumber } from "@ethersproject/bignumber"
 import Divider from "./Divider"
+import { SWAP_TYPES } from "../constants"
+import type { TokenOption } from "../pages/Swap"
 import classnames from "classnames"
 import { commify } from "../utils"
 import { formatBNToString } from "../utils"
 import styles from "./SearchSelect.module.scss"
 import { useTranslation } from "react-i18next"
 
-interface TokenData {
-  name: string
-  valueUSD: BigNumber
-  amount: BigNumber
-  icon: string
-  symbol: string
-  decimals: number
-  isAvailable: boolean
-}
 interface Props {
-  tokensData: TokenData[]
+  tokensData: TokenOption[]
   onSelect: (symbol: string) => void
   value?: string
 }
@@ -141,8 +133,15 @@ function ListItem({
   decimals,
   isActive,
   isAvailable,
-}: TokenData & { isActive: boolean }) {
+  swapType,
+}: TokenOption & { isActive: boolean }) {
   const { t } = useTranslation()
+  const isVirtualSwap = ([
+    SWAP_TYPES.SYNTH_TO_SYNTH,
+    SWAP_TYPES.SYNTH_TO_TOKEN,
+    SWAP_TYPES.TOKEN_TO_SYNTH,
+    SWAP_TYPES.TOKEN_TO_TOKEN,
+  ] as Array<SWAP_TYPES | null>).includes(swapType)
   return (
     <div
       className={classnames(styles.listItem, {
@@ -157,6 +156,9 @@ function ListItem({
           <b>{symbol}</b>
           {!isAvailable && (
             <span className={styles.unavailableTag}>{t("unavailable")}</span>
+          )}
+          {isAvailable && isVirtualSwap && (
+            <span className={styles.virtualSwapTag}>{t("virtualSwap")}</span>
           )}
         </div>
         <p className={styles.textMinor}>{name}</p>

--- a/src/components/SwapInput.tsx
+++ b/src/components/SwapInput.tsx
@@ -3,6 +3,7 @@ import React, { ReactElement, useCallback, useRef, useState } from "react"
 import { BigNumber } from "@ethersproject/bignumber"
 import SearchSelect from "./SearchSelect"
 import { TOKENS_MAP } from "../constants"
+import type { TokenOption } from "../pages/Swap"
 import classnames from "classnames"
 import { commify } from "../utils"
 import { formatBNToString } from "../utils"
@@ -11,15 +12,7 @@ import useDetectOutsideClick from "../hooks/useDetectOutsideClick"
 import { useTranslation } from "react-i18next"
 
 interface Props {
-  tokens: Array<{
-    name: string
-    valueUSD: BigNumber
-    amount: BigNumber
-    icon: string
-    symbol: string
-    decimals: number
-    isAvailable: boolean
-  }>
+  tokens: TokenOption[]
   selected: string
   inputValue: string
   inputValueUSD: BigNumber

--- a/src/components/SwapInput.tsx
+++ b/src/components/SwapInput.tsx
@@ -96,7 +96,7 @@ export default function SwapInput({
           type="text"
           placeholder="0.0"
           spellCheck="false"
-          value={commify(inputValue)}
+          value={isSwapFrom ? inputValue : commify(inputValue)}
           onChange={(e) => {
             // remove all chars that aren't a digit or a period
             const newValue = e.target.value.replace(/[^\d|.]/g, "")

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -83,10 +83,8 @@ const SwapPage = (props: Props): ReactElement => {
   const formattedPriceImpact = commify(
     formatBNToPercentString(exchangeRateInfo.priceImpact, 18),
   )
-  const formattedExchangeRate = formatBNToString(
-    exchangeRateInfo.exchangeRate,
-    18,
-    4,
+  const formattedExchangeRate = commify(
+    formatBNToString(exchangeRateInfo.exchangeRate, 18, 6),
   )
   const formattedRoute = exchangeRateInfo.route.join(" > ")
   const formattedBalance = commify(

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -17,6 +17,7 @@ import { PayloadAction } from "@reduxjs/toolkit"
 import ReviewSwap from "./ReviewSwap"
 import SlippageField from "./SlippageField"
 import SwapInput from "./SwapInput"
+import type { TokenOption } from "../pages/Swap"
 import TopMenu from "./TopMenu"
 import { Zero } from "@ethersproject/constants"
 import classNames from "classnames"
@@ -27,15 +28,6 @@ import { updateSwapAdvancedMode } from "../state/user"
 import { useActiveWeb3React } from "../hooks"
 import { useTranslation } from "react-i18next"
 
-interface TokenOption {
-  symbol: string
-  name: string
-  valueUSD: BigNumber
-  amount: BigNumber
-  icon: string
-  decimals: number
-  isAvailable: boolean
-}
 interface Props {
   tokenOptions: {
     from: TokenOption[]
@@ -45,6 +37,7 @@ interface Props {
     pair: string
     exchangeRate: BigNumber
     priceImpact: BigNumber
+    route: string[]
   }
   txnGasCost: {
     amount: BigNumber
@@ -87,15 +80,15 @@ const SwapPage = (props: Props): ReactElement => {
   const { userSwapAdvancedMode: advanced } = useSelector(
     (state: AppState) => state.user,
   )
-  const formattedPriceImpact = formatBNToPercentString(
-    exchangeRateInfo.priceImpact,
-    18,
+  const formattedPriceImpact = commify(
+    formatBNToPercentString(exchangeRateInfo.priceImpact, 18),
   )
   const formattedExchangeRate = formatBNToString(
     exchangeRateInfo.exchangeRate,
     18,
     4,
   )
+  const formattedRoute = exchangeRateInfo.route.join(" > ")
   const formattedBalance = commify(
     formatBNToString(fromToken?.amount || Zero, fromToken?.decimals || 0, 6),
   )
@@ -190,6 +183,12 @@ const SwapPage = (props: Props): ReactElement => {
             <span>{t("priceImpact")}</span>
             <span>{formattedPriceImpact}</span>
           </div>
+          {formattedRoute && (
+            <div className="row">
+              <span>{t("route")}</span>
+              <span>{formattedRoute}</span>
+            </div>
+          )}
         </div>
         {account && isHighPriceImpact(exchangeRateInfo.priceImpact) ? (
           <div className="exchangeWarning">

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -335,11 +335,25 @@ export const TRANSACTION_TYPES = {
 
 export const POOL_FEE_PRECISION = 10
 
+export enum SWAP_TYPES {
+  DIRECT = "swapDirect", // route length 2
+  SYNTH_TO_SYNTH = "swapSynthToSynth", // route length 2
+  SYNTH_TO_TOKEN = "swapSynthToToken", // route length 3
+  TOKEN_TO_SYNTH = "swapTokenToSynth", // route length 3
+  TOKEN_TO_TOKEN = "swapTokenToToken", // route length 4
+  INVALID = "invalid",
+}
+
 export const SWAP_CONTRACT_GAS_ESTIMATES_MAP = {
-  swap: BigNumber.from("200000"), // 157807
-  addLiquidity: BigNumber.from("400000"), // 386555
-  removeLiquidityImbalance: BigNumber.from("350000"), // 318231
-  removeLiquidityOneToken: BigNumber.from("250000"), // 232947
+  [SWAP_TYPES.INVALID]: BigNumber.from("999999999"), // 999,999,999
+  [SWAP_TYPES.DIRECT]: BigNumber.from("200000"), // 157,807
+  [SWAP_TYPES.TOKEN_TO_TOKEN]: BigNumber.from("2000000"), // 1,676,837
+  [SWAP_TYPES.TOKEN_TO_SYNTH]: BigNumber.from("2000000"), // 1,655,502
+  [SWAP_TYPES.SYNTH_TO_TOKEN]: BigNumber.from("1500000"), // 1,153,654
+  [SWAP_TYPES.SYNTH_TO_SYNTH]: BigNumber.from("999999999"), // 999,999,999 // TODO: https://github.com/saddle-finance/saddle-frontend/issues/471
+  addLiquidity: BigNumber.from("400000"), // 386,555
+  removeLiquidityImbalance: BigNumber.from("350000"), // 318,231
+  removeLiquidityOneToken: BigNumber.from("250000"), // 232,947
 }
 
 export interface WalletInfo {
@@ -364,15 +378,6 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
     icon: coinbasewalletIcon,
     connector: walletlink,
   },
-}
-
-export enum SWAP_TYPES {
-  DIRECT = 1, // route length 2
-  SYNTH_TO_SYNTH = 2, // route length 2
-  SYNTH_TO_TOKEN = 3, // route length 3
-  TOKEN_TO_SYNTH = 4, // route length 3
-  TOKEN_TO_TOKEN = 5, // route length 4
-  INVALID = 7,
 }
 
 // FLAGS

--- a/src/hooks/useApproveAndSwap.ts
+++ b/src/hooks/useApproveAndSwap.ts
@@ -1,7 +1,13 @@
-import { TOKENS_MAP, TRANSACTION_TYPES } from "../constants"
+import {
+  POOLS_MAP,
+  SWAP_TYPES,
+  TOKENS_MAP,
+  TRANSACTION_TYPES,
+} from "../constants"
 
 import { AppState } from "../state"
 import { BigNumber } from "@ethersproject/bignumber"
+import { Bridge } from "../../types/ethers-contracts/Bridge"
 import { Erc20 } from "../../types/ethers-contracts/Erc20"
 import { GasPrices } from "../state/user"
 import { SwapFlashLoan } from "../../types/ethers-contracts/SwapFlashLoan"
@@ -17,14 +23,24 @@ import { useAllContracts } from "./useContract"
 import { useDispatch } from "react-redux"
 import { useSelector } from "react-redux"
 import { useToast } from "./useToast"
+import { utils } from "ethers"
 
-interface ApproveAndSwapStateArgument {
-  fromTokenSymbol: string
-  toTokenSymbol: string
-  fromAmount: BigNumber
-  toAmount: BigNumber
+type Contracts = {
   swapContract: SwapFlashLoan | SwapGuarded | null
+  bridgeContract: Bridge | null
 }
+type SwapSide = {
+  amount: BigNumber
+  symbol: string
+  poolName: string
+  tokenIndex: number
+}
+type FormState = {
+  from: SwapSide
+  to: SwapSide & { amountMediumSynth: BigNumber }
+  swapType: Exclude<SWAP_TYPES, SWAP_TYPES.INVALID>
+}
+type ApproveAndSwapStateArgument = FormState & Contracts
 
 export function useApproveAndSwap(): (
   state: ApproveAndSwapStateArgument,
@@ -50,18 +66,22 @@ export function useApproveAndSwap(): (
   ): Promise<void> {
     try {
       if (!account) throw new Error("Wallet must be connected")
-      if (!state.swapContract) throw new Error("Swap contract is not loaded")
+      if (state.swapType === SWAP_TYPES.DIRECT && !state.swapContract)
+        throw new Error("Swap contract is not loaded")
+      if (state.swapType !== SWAP_TYPES.DIRECT && !state.bridgeContract)
+        throw new Error("Bridge contract is not loaded")
       if (chainId === undefined) throw new Error("Unknown chain")
-      const tokenFrom = TOKENS_MAP[state.fromTokenSymbol]
-      const tokenTo = TOKENS_MAP[state.toTokenSymbol]
+      const tokenFrom = TOKENS_MAP[state.from.symbol]
       // For each token being deposited, check the allowance and approve it if necessary
-      const tokenContract = tokenContracts?.[state.fromTokenSymbol] as Erc20
+      const tokenContract = tokenContracts?.[state.from.symbol] as Erc20
       if (tokenContract == null) return
       await checkAndApproveTokenForTrade(
         tokenContract,
-        state.swapContract.address,
+        (state.swapType === SWAP_TYPES.DIRECT
+          ? state.swapContract?.address
+          : state.bridgeContract?.address) as string,
         account,
-        state.fromAmount,
+        state.from.amount,
         infiniteApproval,
         {
           onTransactionStart: () => {
@@ -90,12 +110,6 @@ export function useApproveAndSwap(): (
           },
         },
       )
-
-      let minToMint = state.toAmount
-      console.debug(`MinToMint 1: ${minToMint.toString()}`)
-
-      minToMint = subtractSlippage(minToMint, slippageSelected, slippageCustom)
-      console.debug(`MinToMint 2: ${minToMint.toString()}`)
       const clearMessage = addToast({
         type: "pending",
         title: `${getFormattedTimeString()} Starting your Swap...`,
@@ -111,25 +125,86 @@ export function useApproveAndSwap(): (
         gasPrice = gasStandard
       }
       gasPrice = parseUnits(String(gasPrice) || "45", 9)
-      const [indexFrom, indexTo] = await Promise.all([
-        state.swapContract.getTokenIndex(tokenFrom.addresses[chainId]),
-        state.swapContract.getTokenIndex(tokenTo.addresses[chainId]),
-      ])
-      const deadline = formatDeadlineToNumber(
-        transactionDeadlineSelected,
-        transactionDeadlineCustom,
-      )
-      const swapTransaction = await state.swapContract.swap(
-        indexFrom,
-        indexTo,
-        state.fromAmount,
-        minToMint,
-        Math.round(new Date().getTime() / 1000 + 60 * deadline),
-        {
-          gasPrice,
-        },
-      )
-      await swapTransaction.wait()
+      const txnArgs = { gasPrice }
+      let swapTransaction
+      if (state.swapType === SWAP_TYPES.TOKEN_TO_TOKEN) {
+        const originPool = POOLS_MAP[state.from.poolName]
+        const destinationPool = POOLS_MAP[state.to.poolName]
+        const args = [
+          [
+            originPool.addresses[chainId],
+            destinationPool.addresses[chainId],
+          ] as [string, string],
+          state.from.tokenIndex,
+          state.to.tokenIndex,
+          state.from.amount,
+          subtractSlippage(
+            state.to.amountMediumSynth,
+            slippageSelected,
+            slippageCustom,
+          ), // subtract slippage from minSynth
+          txnArgs,
+        ] as const
+        swapTransaction = await (state.bridgeContract as Bridge).tokenToToken(
+          ...args,
+        )
+        console.debug("swap - tokenToToken", args)
+      } else if (state.swapType === SWAP_TYPES.SYNTH_TO_TOKEN) {
+        const destinationPool = POOLS_MAP[state.to.poolName]
+        const args = [
+          destinationPool.addresses[chainId],
+          utils.formatBytes32String(state.from.symbol),
+          state.to.tokenIndex,
+          state.from.amount,
+          subtractSlippage(
+            state.to.amountMediumSynth,
+            slippageSelected,
+            slippageCustom,
+          ), // subtract slippage from minSynth
+          txnArgs,
+        ] as const
+        swapTransaction = await (state.bridgeContract as Bridge).synthToToken(
+          ...args,
+        )
+        console.debug("swap - synthToToken", args)
+      } else if (state.swapType === SWAP_TYPES.TOKEN_TO_SYNTH) {
+        const destinationPool = POOLS_MAP[state.to.poolName]
+        const args = [
+          destinationPool.addresses[chainId],
+          state.from.tokenIndex,
+          utils.formatBytes32String(state.to.symbol),
+          state.from.amount,
+          subtractSlippage(state.to.amount, slippageSelected, slippageCustom),
+          txnArgs,
+        ] as const
+        swapTransaction = await (state.bridgeContract as Bridge).tokenToSynth(
+          ...args,
+        )
+        console.debug("swap - tokenToSynth", args)
+      } else if (state.swapType === SWAP_TYPES.DIRECT) {
+        const deadline = formatDeadlineToNumber(
+          transactionDeadlineSelected,
+          transactionDeadlineCustom,
+        )
+        const args = [
+          state.from.tokenIndex,
+          state.to.tokenIndex,
+          state.from.amount,
+          subtractSlippage(state.to.amount, slippageSelected, slippageCustom),
+          Math.round(new Date().getTime() / 1000 + 60 * deadline),
+          txnArgs,
+        ] as const
+        swapTransaction = await (state.swapContract as NonNullable<
+          typeof state.swapContract // we already check for nonnull above
+        >).swap(...args)
+        console.debug("swap - direct", args)
+      } else if (state.swapType === SWAP_TYPES.SYNTH_TO_SYNTH) {
+        // TODO: support synth to synth
+        throw new Error("Synth to Synth swaps not yet supported")
+      } else {
+        throw new Error("Invalid Swap Type, or contract not loaded")
+      }
+      await swapTransaction?.wait()
       dispatch(
         updateLastTransactionTimes({
           [TRANSACTION_TYPES.SWAP]: Date.now(),

--- a/src/hooks/useCalculateSwapPairs.ts
+++ b/src/hooks/useCalculateSwapPairs.ts
@@ -13,6 +13,16 @@ import {
 import { intersection } from "../utils/index"
 import { useState } from "react"
 
+// swaptypes in order of least to most preferred (aka expensive)
+const SWAP_TYPES_ORDERED_ASC = [
+  SWAP_TYPES.INVALID,
+  SWAP_TYPES.TOKEN_TO_TOKEN,
+  SWAP_TYPES.TOKEN_TO_SYNTH,
+  SWAP_TYPES.SYNTH_TO_TOKEN,
+  SWAP_TYPES.SYNTH_TO_SYNTH,
+  SWAP_TYPES.DIRECT,
+]
+
 type TokenToSwapDataMap = { [symbol: string]: SwapData[] }
 export function useCalculateSwapPairs(): (token?: Token) => SwapData[] {
   const [pairCache, setPairCache] = useState<TokenToSwapDataMap>({})
@@ -201,8 +211,13 @@ function getTradingPairsForToken(
     }
 
     // use this swap only if we haven't already calculated a better swap for the pair
-    const existingTokenSwapData = tokenToSwapDataMap[token.symbol]
-    if (!existingTokenSwapData || existingTokenSwapData.type > swapData.type) {
+    const existingTokenSwapData: SwapData | undefined =
+      tokenToSwapDataMap[token.symbol]
+    const existingSwapIdx = SWAP_TYPES_ORDERED_ASC.indexOf(
+      existingTokenSwapData?.type,
+    )
+    const newSwapIdx = SWAP_TYPES_ORDERED_ASC.indexOf(swapData.type)
+    if (!existingTokenSwapData || newSwapIdx > existingSwapIdx) {
       tokenToSwapDataMap[token.symbol] = swapData
     }
   })

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -25,7 +25,6 @@ import { debounce } from "lodash"
 import { formatGasToString } from "../utils/gas"
 import { useActiveWeb3React } from "../hooks"
 import { useApproveAndSwap } from "../hooks/useApproveAndSwap"
-import usePoolData from "../hooks/usePoolData"
 import { usePoolTokenBalances } from "../state/wallet/hooks"
 import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
@@ -113,9 +112,7 @@ function Swap(): ReactElement {
   const swapContract = useSwapContract(
     formState.to.poolName as PoolName | undefined,
   )
-  const [poolData] = usePoolData(formState.to.poolName as PoolName | undefined)
   // build a representation of pool tokens for the UI
-
   const tokenOptions = useMemo(() => {
     const allTokens = Object.values(TOKENS_MAP)
       .map(({ symbol, name, icon, decimals }) => {
@@ -260,7 +257,6 @@ function Swap(): ReactElement {
         priceImpact = calculatePriceImpact(
           shiftBNDecimals(amountToGive, 18 - tokenFrom.decimals),
           shiftBNDecimals(amountToReceive, 18 - tokenTo.decimals),
-          poolData ? poolData.virtualPrice : BigNumber.from(10).pow(18),
         )
       } else {
         priceImpact = calculatePriceImpact(
@@ -291,7 +287,6 @@ function Swap(): ReactElement {
       tokenBalances,
       swapContract,
       bridgeContract,
-      poolData,
       chainId,
       tokenPricesUSD,
     ],

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -499,7 +499,7 @@ function Swap(): ReactElement {
       gasCustom,
     ),
   )
-  const gasAmount = calculateGasEstimate("swap").mul(gasPrice) // units of gas * GWEI/Unit of gas
+  const gasAmount = calculateGasEstimate(formState.swapType).mul(gasPrice) // units of gas * GWEI/Unit of gas
 
   const txnGasCost = {
     amount: gasAmount,

--- a/src/pages/Swap.tsx
+++ b/src/pages/Swap.tsx
@@ -252,18 +252,10 @@ function Swap(): ReactElement {
         tokenPricesUSD?.[tokenTo.symbol],
         tokenTo.decimals,
       )
-      let priceImpact: BigNumber
-      if (formStateArg.swapType === SWAP_TYPES.DIRECT) {
-        priceImpact = calculatePriceImpact(
-          shiftBNDecimals(amountToGive, 18 - tokenFrom.decimals),
-          shiftBNDecimals(amountToReceive, 18 - tokenTo.decimals),
-        )
-      } else {
-        priceImpact = calculatePriceImpact(
-          formStateArg.from.valueUSD,
-          toValueUSD,
-        )
-      }
+      const priceImpact = calculatePriceImpact(
+        formStateArg.from.valueUSD,
+        toValueUSD,
+      )
       setFormState((prevState) => ({
         ...prevState,
         error,


### PR DESCRIPTION
This PR contains major logic changes that enable Virtual Swaps and calculating swaps. 

This includes removing the `activePool` logic which has been superseded by the `calculateSwapPairs` logic in the swap page. This also adds a couple VS-related fields to the swap form state which come from `calculateSwapPairs` - this includes `poolName, tokenIndex, and swapType`. The txn gas estimate is also updated with real costs for virtual swaps. Finally, this includes a minor logic change of using `tokenPriceUSD` for calculating the price impact of swaps rather than token amount, and also removes the incorrect use of virtualprice when calculating swap price impact. 

To test this locally:
- checkout [this branch](https://github.com/saddle-finance/saddle-frontend/pull/474) of the frontend repo which includes this PR + a local susd pool for testing 
- in `src/constants/index.ts` change `IS_VIRTUAL_SWAP_ACTIVE = true`
- checkout [this branch](https://github.com/saddle-finance/saddle-contract/tree/john/deploy-bridge) of the contract repo, add `FUND_FORK_MAINNET=true` to your local .env, and run `npm run fork`
- connect to the local forked mainnet through your wallet
- do a virtual swap! (note this pr only covers the initial swap actual. The later UI and synth resolution will be in subsequent PRs)