### PR TITLE
Update ethcall library to support Multicall2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Reconfigure git to use HTTP authentication
+      run: >
+        git config --global url."https://github.com/".insteadOf
+        ssh://git@github.com/
     - uses: actions/cache@v2
       with:
         path: ~/.npm
@@ -30,6 +34,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Reconfigure git to use HTTP authentication
+      run: >
+        git config --global url."https://github.com/".insteadOf
+        ssh://git@github.com/
     - uses: actions/cache@v2
       with:
         path: ~/.npm
@@ -50,6 +58,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Reconfigure git to use HTTP authentication
+      run: >
+        git config --global url."https://github.com/".insteadOf
+        ssh://git@github.com/
     - uses: actions/cache@v2
       with:
         path: ~/.npm
@@ -78,6 +90,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+    - name: Reconfigure git to use HTTP authentication
+      run: >
+        git config --global url."https://github.com/".insteadOf
+        ssh://git@github.com/
     - uses: actions/cache@v2
       with:
         path: ~/.npm

--- a/package-lock.json
+++ b/package-lock.json
@@ -48524,7 +48524,7 @@
     },
     "ethcall": {
       "version": "git+ssh://git@github.com/penandlim/ethcall.git#b8c2f9b2df00725b0e61445cc8663b51bbcdb9fa",
-      "from": "ethcall@penandlim/ethcall#multicall2",
+      "from": "ethcall@github:penandlim/ethcall#multicall2",
       "requires": {
         "@ethersproject/abi": "^5.0.0",
         "@ethersproject/contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "async-retry": "^1.3.1",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.3.1",
-        "ethcall": "^3.2.0",
+        "ethcall": "penandlim/ethcall#multicall2",
         "ethers": "^5.1.0",
         "framer-motion": "^4.0.3",
         "history": "^5.0.0",
@@ -17502,9 +17502,9 @@
       }
     },
     "node_modules/ethcall": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ethcall/-/ethcall-3.2.0.tgz",
-      "integrity": "sha512-uYlVWkG8vHsNPqYdobHmcB5K6O58o+Rk4wgGi4rKypCBoSeV3deSVX9BAADnwDVI3MfLuSYndVeK2o0fDUAXvw==",
+      "version": "3.3.0",
+      "resolved": "git+ssh://git@github.com/penandlim/ethcall.git#b8c2f9b2df00725b0e61445cc8663b51bbcdb9fa",
+      "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.0.0",
         "@ethersproject/contracts": "^5.0.0",
@@ -40106,6 +40106,7 @@
       "version": "6.1.21",
       "dev": true,
       "requires": {
+        "@babel/core": "^7.12.1",
         "@babel/generator": "^7.12.1",
         "@babel/parser": "^7.12.3",
         "@babel/plugin-transform-react-jsx": "^7.12.1",
@@ -48522,9 +48523,8 @@
       }
     },
     "ethcall": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ethcall/-/ethcall-3.2.0.tgz",
-      "integrity": "sha512-uYlVWkG8vHsNPqYdobHmcB5K6O58o+Rk4wgGi4rKypCBoSeV3deSVX9BAADnwDVI3MfLuSYndVeK2o0fDUAXvw==",
+      "version": "git+ssh://git@github.com/penandlim/ethcall.git#b8c2f9b2df00725b0e61445cc8663b51bbcdb9fa",
+      "from": "ethcall@penandlim/ethcall#multicall2",
       "requires": {
         "@ethersproject/abi": "^5.0.0",
         "@ethersproject/contracts": "^5.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,7 @@
         "async-retry": "^1.3.1",
         "classnames": "^2.2.6",
         "copy-to-clipboard": "^3.3.1",
-        "ethcall": "penandlim/ethcall#multicall2",
+        "ethcall": "github:penandlim/ethcall#multicall2",
         "ethers": "^5.1.0",
         "framer-motion": "^4.0.3",
         "history": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async-retry": "^1.3.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.3.1",
-    "ethcall": "^3.2.0",
+    "ethcall": "penandlim/ethcall#multicall2",
     "ethers": "^5.1.0",
     "framer-motion": "^4.0.3",
     "history": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "async-retry": "^1.3.1",
     "classnames": "^2.2.6",
     "copy-to-clipboard": "^3.3.1",
-    "ethcall": "penandlim/ethcall#multicall2",
+    "ethcall": "github:penandlim/ethcall#multicall2",
     "ethers": "^5.1.0",
     "framer-motion": "^4.0.3",
     "history": "^5.0.0",

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -382,7 +382,7 @@ async function getSgtApr(
     until,
     rewardsDuration,
     sgtRewardsPerPeriod,
-  ] = await ethcallProvider.all(multicalls, {})
+  ] = await ethcallProvider.all(multicalls)
 
   const nowSeconds = BigNumber.from(Math.floor(Date.now() / 1000))
   const remainingDays = until.sub(nowSeconds).div(60 * 60 * 24) // 1e0

--- a/src/state/wallet/hooks.ts
+++ b/src/state/wallet/hooks.ts
@@ -35,7 +35,7 @@ export function usePoolTokenBalances(): { [token: string]: BigNumber } | null {
           ) as MulticallContract<Erc20>
         })
         .map((c) => c.balanceOf(account))
-      const balances = await ethcallProvider.all(balanceCalls, {})
+      const balances = await ethcallProvider.all(balanceCalls)
 
       const ethBalance = await library.getBalance(account)
       setBalances(

--- a/src/types/ethcall.d.ts
+++ b/src/types/ethcall.d.ts
@@ -26,11 +26,11 @@ export class MulticallProvider extends Provider {
    *  */
   all<A extends MulticallCall>(
     calls: readonly [A],
-    overrides: CallOverrides,
+    block?: number,
   ): Promise<[A["outputs"]]>
   all<A extends MulticallCall, B extends MulticallCall>(
     calls: readonly [A, B],
-    overrides: CallOverrides,
+    block?: number,
   ): Promise<[A["outputs"], B["outputs"]]>
   all<
     A extends MulticallCall,
@@ -38,7 +38,7 @@ export class MulticallProvider extends Provider {
     C extends MulticallCall
   >(
     calls: readonly [A, B, C],
-    overrides: CallOverrides,
+    block?: number,
   ): Promise<[A["outputs"], B["outputs"], C["outputs"]]>
   all<
     A extends MulticallCall,
@@ -47,7 +47,7 @@ export class MulticallProvider extends Provider {
     D extends MulticallCall
   >(
     calls: readonly [A, B, C, D],
-    overrides: CallOverrides,
+    block?: number,
   ): Promise<[A["outputs"], B["outputs"], C["outputs"], D["outputs"]]>
-  all<O>(calls: MulticallCall<I, O>[], overrides: CallOverrides): Promise<O[]> // fallthrough to array type
+  all<O>(calls: MulticallCall<I, O>[], block?: number): Promise<O[]> // fallthrough to array type
 }


### PR DESCRIPTION
Updated ethcall library to support calling `Multicall2.tryAggregate`

`ethcallProvider.tryAll()` will ignore any reverted reads and return null values in place of the failed read call's return values.

If the changes https://github.com/Destiner/ethcall/pull/5 are approved merged in, we should switch back to the npm version.

