### PR TITLE
Display native pool APY and 24h volume on the pools page

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -100,6 +100,7 @@
   "totalAmount": "Total amount",
   "totalLocked": "Total locked",
   "unavailable": "Unavailable",
+  "utilization": "Utilization",
   "usdBalance": "USD balance",
   "virtualPrice": "Virtual price",
   "virtualSwap": "Virtual Swap",
@@ -112,5 +113,6 @@
   "withdrawPercentage": "Withdraw percentage",
   "yes": "Yes",
   "youWillReceive": "You will receive",
-  "yourRecentTransactions": "Your recent transactions will be here."
+  "yourRecentTransactions": "Your recent transactions will be here.",
+  "24HrVolume": "24h Volume"
 }

--- a/public/locales/zh.json
+++ b/public/locales/zh.json
@@ -100,6 +100,7 @@
   "totalLocked": "总锁定值",
   "unavailable": "不可兑换",
   "usdBalance": "美元余额",
+  "utilization": null,
   "virtualPrice": "虚拟价格",
   "virtualSwap": null,
   "volume": "量",
@@ -111,5 +112,6 @@
   "withdrawPercentage": "提取的百分比",
   "yes": "是",
   "youWillReceive": "您会收到",
-  "yourRecentTransactions": "您近期的交易记录会在此显示。"
+  "yourRecentTransactions": "您近期的交易记录会在此显示。",
+  "24HrVolume": null
 }

--- a/src/components/PoolInfoCard.tsx
+++ b/src/components/PoolInfoCard.tsx
@@ -30,6 +30,9 @@ function PoolInfoCard({ data }: Props): ReactElement {
     virtualPrice: data?.virtualPrice
       ? commify(formatBNToString(data.virtualPrice, 18, 5))
       : null,
+    utilization: data?.utilization
+      ? `${formatBNToPercentString(data.utilization, 18, 0)}`
+      : "",
     reserve: data?.reserve
       ? commify(formatBNToString(data.reserve, 18, 2))
       : "0",
@@ -67,6 +70,10 @@ function PoolInfoCard({ data }: Props): ReactElement {
         <div className="infoItem">
           <span className="label bold">{`${t("virtualPrice")}:`}</span>
           <span className="value">{formattedData.virtualPrice}</span>
+        </div>
+        <div className="infoItem">
+          <span className="label bold">{`${t("utilization")}:`}</span>
+          <span className="value">{`$${formattedData.utilization}`}</span>
         </div>
         <div className="infoItem">
           <span className="label bold">{`${t("totalLocked")}:`}</span>

--- a/src/components/PoolInfoCard.tsx
+++ b/src/components/PoolInfoCard.tsx
@@ -26,18 +26,18 @@ function PoolInfoCard({ data }: Props): ReactElement {
     swapFee,
     aParameter: data?.aParameter
       ? commify(formatBNToString(data.aParameter, 0, 0))
-      : null,
+      : "-",
     virtualPrice: data?.virtualPrice
       ? commify(formatBNToString(data.virtualPrice, 18, 5))
-      : null,
+      : "-",
     utilization: data?.utilization
-      ? `${formatBNToPercentString(data.utilization, 18, 0)}`
-      : "",
+      ? commify(formatBNToPercentString(data.utilization, 18, 0))
+      : "-",
     reserve: data?.reserve
       ? commify(formatBNToString(data.reserve, 18, 2))
-      : "0",
+      : "-",
     adminFee: swapFee && adminFee ? `${adminFee} of ${swapFee}` : null,
-    volume: data?.volume,
+    volume: data?.volume ? commify(formatBNToString(data.volume, 0, 0)) : "-",
     tokens:
       data?.tokens.map((coin) => {
         const token = TOKENS_MAP[coin.symbol]

--- a/src/components/PoolInfoCard.tsx
+++ b/src/components/PoolInfoCard.tsx
@@ -39,7 +39,7 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
       ? commify(formatBNToString(data.virtualPrice, 18, 5))
       : "-",
     utilization: data?.utilization
-      ? commify(formatBNToPercentString(data.utilization, 18, 0))
+      ? formatBNToPercentString(data.utilization, 18, 0)
       : "-",
     reserve: data?.reserve
       ? commify(formatBNToString(data.reserve, 18, 2))
@@ -81,7 +81,7 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
         </div>
         <div className="infoItem">
           <span className="label bold">{`${t("utilization")}:`}</span>
-          <span className="value">{`$${formattedData.utilization}`}</span>
+          <span className="value">{formattedData.utilization}</span>
         </div>
         <div className="infoItem">
           <span className="label bold">{`${t("totalLocked")}:`}</span>

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -3,7 +3,11 @@ import "./PoolOverview.scss"
 import { POOLS_MAP, PoolTypes, TOKENS_MAP } from "../constants"
 import { Partners, PoolDataType, UserShareType } from "../hooks/usePoolData"
 import React, { ReactElement } from "react"
-import { formatBNToPercentString, formatBNToString } from "../utils"
+import {
+  formatBNToPercentString,
+  formatBNToShortString,
+  formatBNToString,
+} from "../utils"
 
 import Button from "./Button"
 import { Link } from "react-router-dom"
@@ -28,7 +32,7 @@ function PoolOverview({
   const formattedData = {
     name: poolData.name,
     reserve: poolData.reserve
-      ? commify(formatBNToString(poolData.reserve, 18, 0))
+      ? formatBNToShortString(poolData.reserve, 18)
       : "-",
     aprs: Object.keys(poolData.aprs).reduce((acc, key) => {
       const apr = poolData.aprs[key as Partners]?.apr
@@ -41,10 +45,10 @@ function PoolOverview({
     }, {} as Partial<Record<Partners, string>>),
     apy: poolData.apy ? `${formatBNToPercentString(poolData.apy, 18, 2)}` : "-",
     volume: poolData.volume
-      ? `$${commify(formatBNToString(poolData.volume, 18, 2))}`
+      ? `$${formatBNToShortString(poolData.volume, 18)}`
       : "-",
     userBalanceUSD: commify(
-      formatBNToString(userShareData?.usdBalance || Zero, 18, 2),
+      formatBNToShortString(userShareData?.usdBalance || Zero, 18),
     ),
     tokens: poolData.tokens.map((coin) => {
       const token = TOKENS_MAP[coin.symbol]
@@ -104,7 +108,7 @@ function PoolOverview({
             <span>{`$${formattedData.reserve}`}</span>
           </div>
           {formattedData.volume && (
-            <div className="margin">
+            <div>
               <span className="label">{`${t("24HrVolume")}`}</span>
               <span>{formattedData.volume}</span>
             </div>

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -12,7 +12,6 @@ import {
 import Button from "./Button"
 import { Link } from "react-router-dom"
 import { Zero } from "@ethersproject/constants"
-import { commify } from "@ethersproject/units"
 import { useTranslation } from "react-i18next"
 
 interface Props {
@@ -47,8 +46,9 @@ function PoolOverview({
     volume: poolData.volume
       ? `$${formatBNToShortString(poolData.volume, 18)}`
       : "-",
-    userBalanceUSD: commify(
-      formatBNToShortString(userShareData?.usdBalance || Zero, 18),
+    userBalanceUSD: formatBNToShortString(
+      userShareData?.usdBalance || Zero,
+      18,
     ),
     tokens: poolData.tokens.map((coin) => {
       const token = TOKENS_MAP[coin.symbol]

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -25,7 +25,7 @@ function PoolOverview({
   const { t } = useTranslation()
   const formattedData = {
     name: poolData.name,
-    reserve: commify(formatBNToString(poolData.reserve, 18, 2)),
+    reserve: commify(formatBNToString(poolData.reserve, 18, 0)),
     aprs: Object.keys(poolData.aprs).reduce((acc, key) => {
       const apr = poolData.aprs[key as Partners]?.apr
       return apr
@@ -35,14 +35,9 @@ function PoolOverview({
           }
         : acc
     }, {} as Partial<Record<Partners, string>>),
-    apy: poolData.apy
-      ? String((100 * parseFloat(poolData.apy)).toFixed(1)) + "%"
-      : "",
+    apy: poolData.APY ? `${formatBNToPercentString(poolData.APY, 18, 2)}` : "",
     volume: poolData.volume
-      ? "$" + commify(parseFloat(poolData.volume).toFixed(0))
-      : "",
-    utilization: poolData.utilization
-      ? String((100 * parseFloat(poolData.utilization)).toFixed(0) + "%")
+      ? `$${commify(formatBNToString(poolData.volume, 18, 2))}`
       : "",
     userBalanceUSD: commify(
       formatBNToString(userShareData?.usdBalance || Zero, 18, 2),
@@ -83,6 +78,12 @@ function PoolOverview({
 
       <div className="right">
         <div className="poolInfo">
+          {formattedData.apy && (
+            <div className="margin">
+              <span className="label">{`${t("apy")}`}</span>
+              <span>{formattedData.apy}</span>
+            </div>
+          )}
           {Object.keys(poolData.aprs).map((key) => {
             const symbol = poolData.aprs[key as Partners]?.symbol as string
             return poolData.aprs[key as Partners]?.apr.gt(Zero) ? (
@@ -94,26 +95,13 @@ function PoolOverview({
               </div>
             ) : null
           })}
-
-          <div className="volume">
+          <div className="margin">
             <span className="label">{t("currencyReserves")}</span>
             <span>{`$${formattedData.reserve}`}</span>
           </div>
-          {formattedData.utilization && (
-            <div className="volume">
-              <span className="label">Utilization</span>
-              <span>{formattedData.utilization}</span>
-            </div>
-          )}
-          {formattedData.apy && (
-            <div className="volume">
-              <span className="label">APY</span>
-              <span>{formattedData.apy}</span>
-            </div>
-          )}
           {formattedData.volume && (
-            <div className="volume">
-              <span className="label">24h Volume</span>
+            <div className="margin">
+              <span className="label">{`${t("24HrVolume")}`}</span>
               <span>{formattedData.volume}</span>
             </div>
           )}

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -35,6 +35,15 @@ function PoolOverview({
           }
         : acc
     }, {} as Partial<Record<Partners, string>>),
+    apy: poolData.apy
+      ? String((100 * parseFloat(poolData.apy)).toFixed(1)) + "%"
+      : "",
+    volume: poolData.volume
+      ? "$" + commify(parseFloat(poolData.volume).toFixed(0))
+      : "",
+    utilization: poolData.utilization
+      ? String((100 * parseFloat(poolData.utilization)).toFixed(0) + "%")
+      : "",
     userBalanceUSD: commify(
       formatBNToString(userShareData?.usdBalance || Zero, 18, 2),
     ),
@@ -48,7 +57,6 @@ function PoolOverview({
       }
     }),
   }
-
   const hasShare = !!userShareData?.usdBalance.gt("0")
 
   return (
@@ -91,6 +99,24 @@ function PoolOverview({
             <span className="label">{t("currencyReserves")}</span>
             <span>{`$${formattedData.reserve}`}</span>
           </div>
+          {formattedData.utilization && (
+            <div className="volume">
+              <span className="label">Utilization</span>
+              <span>{formattedData.utilization}</span>
+            </div>
+          )}
+          {formattedData.apy && (
+            <div className="volume">
+              <span className="label">APY</span>
+              <span>{formattedData.apy}</span>
+            </div>
+          )}
+          {formattedData.volume && (
+            <div className="volume">
+              <span className="label">24h Volume</span>
+              <span>{formattedData.volume}</span>
+            </div>
+          )}
         </div>
         <div className="buttons">
           <Link to={`${poolRoute}/withdraw`}>

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -25,7 +25,9 @@ function PoolOverview({
   const { t } = useTranslation()
   const formattedData = {
     name: poolData.name,
-    reserve: commify(formatBNToString(poolData.reserve, 18, 0)),
+    reserve: poolData.reserve
+      ? commify(formatBNToString(poolData.reserve, 18, 0))
+      : "-",
     aprs: Object.keys(poolData.aprs).reduce((acc, key) => {
       const apr = poolData.aprs[key as Partners]?.apr
       return apr
@@ -35,10 +37,10 @@ function PoolOverview({
           }
         : acc
     }, {} as Partial<Record<Partners, string>>),
-    apy: poolData.APY ? `${formatBNToPercentString(poolData.APY, 18, 2)}` : "",
+    apy: poolData.apy ? `${formatBNToPercentString(poolData.apy, 18, 2)}` : "-",
     volume: poolData.volume
       ? `$${commify(formatBNToString(poolData.volume, 18, 2))}`
-      : "",
+      : "-",
     userBalanceUSD: commify(
       formatBNToString(userShareData?.usdBalance || Zero, 18, 2),
     ),

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -1,7 +1,6 @@
 import {
   ALETH_POOL_NAME,
   BTC_POOL_NAME,
-  ChainId,
   POOLS_MAP,
   PoolName,
   TRANSACTION_TYPES,
@@ -269,8 +268,8 @@ export default function usePoolData(
         value: userPoolTokenBalances[i],
       }))
       const { oneDayVolume, TVL, APY } =
-        swapStats && POOL.addresses[ChainId.MAINNET].toLowerCase() in swapStats
-          ? swapStats[POOL.addresses[ChainId.MAINNET].toLowerCase()]
+        swapStats && POOL.addresses[chainId].toLowerCase() in swapStats
+          ? swapStats[POOL.addresses[chainId].toLowerCase()]
           : { oneDayVolume: "", TVL: "", APY: "" }
       const utilization =
         oneDayVolume && TVL

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -33,15 +33,15 @@ export type Partners = "keep" | "sharedStake" | "alchemix"
 export interface PoolDataType {
   adminFee: BigNumber
   aParameter: BigNumber
-  APY: BigNumber
+  apy: BigNumber | null
   name: string
-  reserve: BigNumber
+  reserve: BigNumber | null
   swapFee: BigNumber
   tokens: TokenShareType[]
   totalLocked: BigNumber
-  utilization: BigNumber
+  utilization: BigNumber | null
   virtualPrice: BigNumber
-  volume: BigNumber
+  volume: BigNumber | null
   aprs: Partial<
     Record<
       Partners,
@@ -70,15 +70,15 @@ export type PoolDataHookReturnType = [PoolDataType, UserShareType | null]
 const emptyPoolData = {
   adminFee: Zero,
   aParameter: Zero,
-  APY: Zero,
+  apy: null,
   name: "",
-  reserve: Zero,
+  reserve: null,
   swapFee: Zero,
   tokens: [],
   totalLocked: Zero,
-  utilization: Zero,
+  utilization: null,
   virtualPrice: Zero,
-  volume: Zero,
+  volume: null,
   aprs: {},
   lpTokenPriceUSD: Zero,
 } as PoolDataType
@@ -267,11 +267,10 @@ export default function usePoolData(
         ),
         value: userPoolTokenBalances[i],
       }))
-      const { oneDayVolume, TVL, APY } =
+      const { oneDayVolume, apy, utilization } =
         swapStats && POOL.addresses[chainId].toLowerCase() in swapStats
           ? swapStats[POOL.addresses[chainId].toLowerCase()]
-          : { oneDayVolume: 0, TVL: 0, APY: 0 }
-      const utilization = oneDayVolume && TVL ? oneDayVolume / TVL : 0
+          : { oneDayVolume: null, apy: null, utilization: null }
       const poolData = {
         name: poolName,
         tokens: poolTokens,
@@ -281,9 +280,9 @@ export default function usePoolData(
         adminFee: adminFee as BigNumber,
         swapFee: swapFee as BigNumber,
         aParameter: aParameter as BigNumber,
-        volume: parseUnits(oneDayVolume.toFixed(18), 18),
-        utilization: parseUnits(utilization.toFixed(18), 18),
-        APY: parseUnits(APY.toFixed(18), 18),
+        volume: oneDayVolume,
+        utilization: utilization,
+        apy: apy,
         aprs,
         lpTokenPriceUSD,
       }

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -244,9 +244,10 @@ export default function usePoolData(
         ),
         value: userPoolTokenBalances[i],
       }))
+      const poolAddress = POOL.addresses[chainId].toLowerCase()
       const { oneDayVolume, apy, utilization } =
-        swapStats && POOL.addresses[chainId].toLowerCase() in swapStats
-          ? swapStats[POOL.addresses[chainId].toLowerCase()]
+        swapStats && poolAddress in swapStats
+          ? swapStats[poolAddress]
           : { oneDayVolume: null, apy: null, utilization: null }
       const poolData = {
         name: poolName,

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -33,15 +33,15 @@ export type Partners = "keep" | "sharedStake" | "alchemix"
 export interface PoolDataType {
   adminFee: BigNumber
   aParameter: BigNumber
-  apy: string
+  APY: BigNumber
   name: string
   reserve: BigNumber
   swapFee: BigNumber
   tokens: TokenShareType[]
   totalLocked: BigNumber
-  utilization: string // TODO: calculate
+  utilization: BigNumber
   virtualPrice: BigNumber
-  volume: string
+  volume: BigNumber
   aprs: Partial<
     Record<
       Partners,
@@ -70,15 +70,15 @@ export type PoolDataHookReturnType = [PoolDataType, UserShareType | null]
 const emptyPoolData = {
   adminFee: Zero,
   aParameter: Zero,
-  apy: "",
+  APY: Zero,
   name: "",
   reserve: Zero,
   swapFee: Zero,
   tokens: [],
   totalLocked: Zero,
-  utilization: "",
+  utilization: Zero,
   virtualPrice: Zero,
-  volume: "",
+  volume: Zero,
   aprs: {},
   lpTokenPriceUSD: Zero,
 } as PoolDataType
@@ -270,11 +270,8 @@ export default function usePoolData(
       const { oneDayVolume, TVL, APY } =
         swapStats && POOL.addresses[chainId].toLowerCase() in swapStats
           ? swapStats[POOL.addresses[chainId].toLowerCase()]
-          : { oneDayVolume: "", TVL: "", APY: "" }
-      const utilization =
-        oneDayVolume && TVL
-          ? String(parseFloat(oneDayVolume) / parseFloat(TVL))
-          : ""
+          : { oneDayVolume: 0, TVL: 0, APY: 0 }
+      const utilization = oneDayVolume && TVL ? oneDayVolume / TVL : 0
       const poolData = {
         name: poolName,
         tokens: poolTokens,
@@ -284,9 +281,9 @@ export default function usePoolData(
         adminFee: adminFee as BigNumber,
         swapFee: swapFee as BigNumber,
         aParameter: aParameter as BigNumber,
-        volume: oneDayVolume,
-        utilization: utilization,
-        apy: APY,
+        volume: parseUnits(oneDayVolume.toFixed(18), 18),
+        utilization: parseUnits(utilization.toFixed(18), 18),
+        APY: parseUnits(APY.toFixed(18), 18),
         aprs,
         lpTokenPriceUSD,
       }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -20,6 +20,7 @@ import ToastsProvider from "../providers/ToastsProvider"
 import Web3ReactManager from "../components/Web3ReactManager"
 import Withdraw from "./Withdraw"
 import fetchGasPrices from "../utils/updateGasPrices"
+import fetchSwapStats from "../utils/getSwapStats"
 import fetchTokenPricesUSD from "../utils/updateTokenPrices"
 import { useActiveWeb3React } from "../hooks"
 import { useDispatch } from "react-redux"
@@ -113,7 +114,11 @@ function GasAndTokenPrices({
   const fetchAndUpdateTokensPrice = useCallback(() => {
     fetchTokenPricesUSD(dispatch, chainId, library)
   }, [dispatch, chainId, library])
+  const fetchAndUpdateSwapStats = useCallback(() => {
+    void fetchSwapStats(dispatch)
+  }, [dispatch])
   usePoller(fetchAndUpdateGasPrice, BLOCK_TIME)
   usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
+  usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 3)
   return <>{children}</>
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -119,6 +119,6 @@ function GasAndTokenPrices({
   }, [dispatch])
   usePoller(fetchAndUpdateGasPrice, BLOCK_TIME)
   usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
-  usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 3)
+  usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 280) // ~ 1hr
   return <>{children}</>
 }

--- a/src/state/application.ts
+++ b/src/state/application.ts
@@ -5,6 +5,13 @@ interface GasPrices {
   gasFast?: number
   gasInstant?: number
 }
+interface SwapStats {
+  [swapAddress: string]: {
+    oneDayVolume: string
+    APY: string
+    TVL: string
+  }
+}
 export interface TokenPricesUSD {
   [tokenSymbol: string]: number
 }
@@ -14,7 +21,7 @@ interface LastTransactionTimes {
 
 type ApplicationState = GasPrices & { tokenPricesUSD?: TokenPricesUSD } & {
   lastTransactionTimes: LastTransactionTimes
-}
+} & { swapStats?: SwapStats }
 
 const initialState: ApplicationState = {
   lastTransactionTimes: {},
@@ -42,6 +49,9 @@ const applicationSlice = createSlice({
         ...action.payload,
       }
     },
+    updateSwapStats(state, action: PayloadAction<SwapStats>): void {
+      state.swapStats = action.payload
+    },
   },
 })
 
@@ -49,6 +59,7 @@ export const {
   updateGasPrices,
   updateTokensPricesUSD,
   updateLastTransactionTimes,
+  updateSwapStats,
 } = applicationSlice.actions
 
 export default applicationSlice.reducer

--- a/src/state/application.ts
+++ b/src/state/application.ts
@@ -7,9 +7,9 @@ interface GasPrices {
 }
 interface SwapStats {
   [swapAddress: string]: {
-    oneDayVolume: string
-    APY: string
-    TVL: string
+    oneDayVolume: number
+    APY: number
+    TVL: number
   }
 }
 export interface TokenPricesUSD {

--- a/src/state/application.ts
+++ b/src/state/application.ts
@@ -2,6 +2,7 @@ import { PayloadAction, createSlice } from "@reduxjs/toolkit"
 
 import { BigNumber } from "@ethersproject/bignumber"
 import { SwapStatsReponse } from "../utils/getSwapStats"
+import { Zero } from "@ethersproject/constants"
 import { parseUnits } from "@ethersproject/units"
 
 interface GasPrices {
@@ -70,9 +71,9 @@ const applicationSlice = createSlice({
               apy,
               tvl,
               oneDayVolume,
-              utilization: oneDayVolume
-                .mul(BigNumber.from(10).pow(18))
-                .div(tvl), // 1e18
+              utilization: tvl.gt("0")
+                ? oneDayVolume.mul(BigNumber.from(10).pow(18)).div(tvl) // 1e18
+                : Zero,
             },
           }
         },

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -1,6 +1,7 @@
 import {
   calculateExchangeRate,
   commify,
+  formatBNToShortString,
   getTokenByAddress,
   intersection,
 } from "../index"
@@ -8,6 +9,22 @@ import {
 import { TOKENS_MAP } from "../../constants/index"
 import { Zero } from "@ethersproject/constants"
 import { parseUnits } from "@ethersproject/units"
+
+describe("formatBNToShortString", () => {
+  const testCases = [
+    ["decimals", parseUnits("1234", 0), 5, "0.0"],
+    ["hundreds", parseUnits("123", 1), 1, "123.0"],
+    ["thousands", parseUnits("5432", 0), 0, "5.4k"],
+    ["millions", parseUnits("66711111", 3), 3, "66.7m"],
+    ["billions", parseUnits("999311111111", 5), 5, "999.3b"],
+    ["trillions", parseUnits("1911111111111", 8), 8, "1.9t"],
+  ] as const
+  testCases.forEach(([type, input, decimals, expected]) => {
+    it(`correctly formats ${type}`, () => {
+      expect(formatBNToShortString(input, decimals)).toEqual(expected)
+    })
+  })
+})
 
 describe("getTokenByAddress", () => {
   it("correctly fetches a token", () => {

--- a/src/utils/getSwapStats.ts
+++ b/src/utils/getSwapStats.ts
@@ -4,7 +4,7 @@ import { updateSwapStats } from "../state/application"
 
 const swapStatsURI = "https://ipfs.saddle.exchange/swap-stats.json"
 
-interface SwapStatsReponse {
+export interface SwapStatsReponse {
   [swapAddress: string]: {
     oneDayVolume: number
     APY: number

--- a/src/utils/getSwapStats.ts
+++ b/src/utils/getSwapStats.ts
@@ -1,0 +1,36 @@
+import { AppDispatch } from "../state"
+import retry from "async-retry"
+import { updateSwapStats } from "../state/application"
+
+const swapStatsURI = "https://ipfs.saddle.exchange/swap-stats.json"
+
+interface SwapStatsReponse {
+  [swapAddress: string]: {
+    oneDayVolume: string
+    APY: string
+    TVL: string
+  }
+}
+
+const fetchSwapStatsNow = (): Promise<SwapStatsReponse> =>
+  fetch(`${swapStatsURI}`)
+    .then((res) => {
+      if (res.status >= 200 && res.status < 300) {
+        return res.json()
+      }
+      throw new Error("Unable to fetch swap stats from IPFS")
+    })
+    .then((body: SwapStatsReponse) => {
+      return body
+    })
+
+export default async function fetchSwapStats(
+  dispatch: AppDispatch,
+): Promise<void> {
+  const dispatchUpdate = (swapStats: SwapStatsReponse) => {
+    dispatch(updateSwapStats(swapStats))
+  }
+  await retry(() => fetchSwapStatsNow().then(dispatchUpdate), {
+    retries: 3,
+  })
+}

--- a/src/utils/getSwapStats.ts
+++ b/src/utils/getSwapStats.ts
@@ -6,9 +6,9 @@ const swapStatsURI = "https://ipfs.saddle.exchange/swap-stats.json"
 
 interface SwapStatsReponse {
   [swapAddress: string]: {
-    oneDayVolume: string
-    APY: string
-    TVL: string
+    oneDayVolume: number
+    APY: number
+    TVL: number
   }
 }
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -48,6 +48,19 @@ export function getContract(
   return new Contract(address, ABI, getProviderOrSigner(library, account))
 }
 
+export function formatBNToShortString(
+  bn: BigNumber,
+  nativePrecision: number,
+): string {
+  const bnStr = bn.toString()
+  const numLen = bnStr.length - nativePrecision
+  if (numLen <= 0) return "0.0"
+  const div = Math.floor((numLen - 1) / 3)
+  const mod = numLen % 3
+  const suffixes = ["", "k", "m", "b", "t"]
+  return `${bnStr.substr(0, mod || 3)}.${bnStr[mod || 3]}${suffixes[div]}`
+}
+
 export function formatBNToString(
   bn: BigNumber,
   nativePrecison: number,


### PR DESCRIPTION
Pull in swap stats from json API, add to redux state, thread through to UI. Add new short format option for bigNumbers. 
Note: We'll need to add both the alUSD pool and the 4pool to the graph for this to be useful across the board

![Screen Shot 2021-06-28 at 7 39 52 PM](https://user-images.githubusercontent.com/7607886/123728801-c2a88100-d848-11eb-9a8c-662f4a547593.png)
