### PR TITLE
Sort swap orders by pool TVL

### DIFF
--- a/src/hooks/__tests__/useCalculateSwapPairs.ts
+++ b/src/hooks/__tests__/useCalculateSwapPairs.ts
@@ -1,4 +1,11 @@
-import { ChainId, Pool, SWAP_TYPES, Token } from "../../constants/index"
+import {
+  ChainId,
+  Pool,
+  PoolName,
+  PoolTypes,
+  SWAP_TYPES,
+  Token,
+} from "../../constants/index"
 
 import { __test__ } from "../useCalculateSwapPairs"
 
@@ -18,13 +25,18 @@ const createTestToken = (name: string, isSynth?: boolean) => {
   return new Token(chainObject, 0, name, "", name, "", !!isSynth)
 }
 
-const createTestPool = (name: string, tokens: Token[]) => {
+const createTestPool = (
+  name: string,
+  tokens: Token[],
+  type = PoolTypes.USD,
+): Pool => {
   return {
-    name: name,
+    name: name as PoolName, // not true but it's a test
     lpToken: createTestToken(`${name} LPToken`),
     poolTokens: tokens,
     isSynthetic: tokens.some(({ isSynthetic }) => isSynthetic),
     addresses: {} as { [chainId in ChainId]: string },
+    type,
   }
 }
 describe("getTradingPairsForToken", () => {
@@ -49,7 +61,7 @@ describe("getTradingPairsForToken", () => {
   )
   const poolsMap = allPools.reduce(
     (acc, p) => ({ ...acc, [p.name]: p }),
-    {} as { [symbol: string]: Pool },
+    {} as { [poolName: string]: Pool },
   )
   const tokensToPoolsMap = {
     [tokenA.symbol]: [pool1.name],
@@ -64,6 +76,7 @@ describe("getTradingPairsForToken", () => {
     const pairs = getTradingPairsForToken(
       tokensMap,
       poolsMap,
+      allPools,
       tokensToPoolsMap,
       tokenA,
     )
@@ -90,6 +103,7 @@ describe("getTradingPairsForToken", () => {
     const pairs = getTradingPairsForToken(
       tokensMap,
       poolsMap,
+      allPools,
       tokensToPoolsMap,
       tokenA,
     )
@@ -119,6 +133,7 @@ describe("getTradingPairsForToken", () => {
     const pairs = getTradingPairsForToken(
       tokensMap,
       poolsMap,
+      allPools,
       tokensToPoolsMap,
       tokenE,
     )
@@ -144,6 +159,7 @@ describe("getTradingPairsForToken", () => {
     const pairs = getTradingPairsForToken(
       tokensMap,
       poolsMap,
+      allPools,
       tokensToPoolsMap,
       tokenF,
     )
@@ -169,6 +185,7 @@ describe("getTradingPairsForToken", () => {
     const pairs = getTradingPairsForToken(
       tokensMap,
       poolsMap,
+      allPools,
       tokensToPoolsMap,
       tokenC,
     )
@@ -194,6 +211,7 @@ describe("getTradingPairsForToken", () => {
     const pairs = getTradingPairsForToken(
       tokensMap,
       poolsMap,
+      allPools,
       tokensToPoolsMap,
       tokenC,
     )

--- a/src/hooks/useCalculateSwapPairs.ts
+++ b/src/hooks/useCalculateSwapPairs.ts
@@ -4,14 +4,13 @@ import {
   PoolsMap,
   SWAP_TYPES,
   TOKENS_MAP,
-  TOKEN_TO_POOLS_MAP,
   Token,
-  TokenToPoolsMap,
   TokensMap,
 } from "../constants/index"
+import { useMemo, useState } from "react"
 
 import { intersection } from "../utils/index"
-import { useState } from "react"
+import usePoolTVLs from "./usePoolsTVL"
 
 // swaptypes in order of least to most preferred (aka expensive)
 const SWAP_TYPES_ORDERED_ASC = [
@@ -23,9 +22,33 @@ const SWAP_TYPES_ORDERED_ASC = [
   SWAP_TYPES.DIRECT,
 ]
 
+type TokenToPoolsMap = {
+  [tokenSymbol: string]: string[]
+}
+
 type TokenToSwapDataMap = { [symbol: string]: SwapData[] }
 export function useCalculateSwapPairs(): (token?: Token) => SwapData[] {
   const [pairCache, setPairCache] = useState<TokenToSwapDataMap>({})
+  const poolTVLs = usePoolTVLs()
+  const [poolsSortedByTVL, tokenToPoolsMapSorted] = useMemo(() => {
+    const sortedPools = Object.values(POOLS_MAP).sort((a, b) => {
+      const aTVL = poolTVLs[a.name]
+      const bTVL = poolTVLs[b.name]
+      if (aTVL && bTVL) {
+        return aTVL.gt(bTVL) ? -1 : 1
+      }
+      return aTVL ? -1 : 1
+    })
+    const tokenToPools = sortedPools.reduce((acc, { name: poolName }) => {
+      const pool = POOLS_MAP[poolName]
+      const newAcc = { ...acc }
+      pool.poolTokens.forEach((token) => {
+        newAcc[token.symbol] = (newAcc[token.symbol] || []).concat(poolName)
+      })
+      return newAcc
+    }, {} as TokenToPoolsMap)
+    return [sortedPools, tokenToPools]
+  }, [poolTVLs])
 
   return function calculateSwapPairs(token?: Token): SwapData[] {
     if (!token) return []
@@ -34,7 +57,8 @@ export function useCalculateSwapPairs(): (token?: Token) => SwapData[] {
     const swapPairs = getTradingPairsForToken(
       TOKENS_MAP,
       POOLS_MAP,
-      TOKEN_TO_POOLS_MAP,
+      poolsSortedByTVL,
+      tokenToPoolsMapSorted,
       token,
     )
     setPairCache((prevState) => ({ ...prevState, [token.symbol]: swapPairs }))
@@ -78,12 +102,13 @@ export type SwapData =
 function getTradingPairsForToken(
   tokensMap: TokensMap,
   poolsMap: PoolsMap,
+  poolsSortedByTVL: Pool[],
   tokenToPoolsMap: TokenToPoolsMap,
   originToken: Token,
 ): SwapData[] {
   const allTokens = Object.values(tokensMap)
   const synthPoolsSet = new Set(
-    Object.values(poolsMap).filter(({ isSynthetic }) => isSynthetic),
+    poolsSortedByTVL.filter(({ isSynthetic }) => isSynthetic),
   )
   const originTokenPoolsSet = new Set(
     tokenToPoolsMap[originToken.symbol].map((poolName) => poolsMap[poolName]),

--- a/src/hooks/usePoolsTVL.ts
+++ b/src/hooks/usePoolsTVL.ts
@@ -1,0 +1,79 @@
+import { ChainId, POOLS_MAP, PoolName, PoolTypes } from "../constants"
+import { Contract, Provider } from "ethcall"
+import { MulticallContract, MulticallProvider } from "../types/ethcall"
+import { useEffect, useState } from "react"
+
+import { AppState } from "../state"
+import { BigNumber } from "@ethersproject/bignumber"
+import LPTOKEN_UNGUARDED_ABI from "../constants/abis/lpTokenUnguarded.json"
+import { LpTokenUnguarded } from "../../types/ethers-contracts/LpTokenUnguarded"
+import { parseUnits } from "@ethersproject/units"
+import { useActiveWeb3React } from "."
+import { useSelector } from "react-redux"
+
+export default function usePoolTVLs(): { [poolName in PoolName]?: BigNumber } {
+  const { chainId, library } = useActiveWeb3React()
+  const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
+  const [poolTvls, setPoolTvls] = useState<
+    { [poolName in PoolName]?: BigNumber }
+  >({})
+
+  useEffect(() => {
+    if (
+      Object.keys(poolTvls).length > 0 && // only run once
+      tokenPricesUSD?.BTC &&
+      tokenPricesUSD?.ETH
+    )
+      return
+    async function fetchTVLs() {
+      if (!library || !chainId) return
+      const ethcallProvider = new Provider() as MulticallProvider
+
+      await ethcallProvider.init(library)
+      // override the contract address when using hardhat
+      if (chainId == ChainId.HARDHAT) {
+        ethcallProvider.multicallAddress =
+          "0xa85233C63b9Ee964Add6F2cffe00Fd84eb32338f"
+      } else if (chainId == ChainId.ROPSTEN) {
+        ethcallProvider.multicallAddress =
+          "0x53c43764255c17bd724f74c4ef150724ac50a3ed"
+      }
+
+      const pools = Object.values(POOLS_MAP)
+      const supplyCalls = pools
+        .map((p) => {
+          return new Contract(
+            p.lpToken.addresses[chainId],
+            LPTOKEN_UNGUARDED_ABI,
+          ) as MulticallContract<LpTokenUnguarded>
+        })
+        .map((c) => c.totalSupply())
+      const tvls = await ethcallProvider.all(supplyCalls, {})
+      const tvlsUSD = pools.map((pool, i) => {
+        const tvlAmount = tvls[i]
+        let tokenValue = 0
+        if (pool.type === PoolTypes.BTC) {
+          tokenValue = tokenPricesUSD?.BTC || 0
+        } else if (pool.type === PoolTypes.ETH) {
+          tokenValue = tokenPricesUSD?.ETH || 0
+        } else {
+          tokenValue = 1 // USD
+        }
+        return parseUnits(tokenValue.toFixed(2), 2)
+          .mul(tvlAmount)
+          .div(BigNumber.from(10).pow(2)) //1e18
+      })
+      setPoolTvls((prevState) => {
+        return pools.reduce(
+          (acc, pool, i) => ({
+            ...acc,
+            [pool.name]: tvlsUSD[i],
+          }),
+          prevState,
+        )
+      })
+    }
+    void fetchTVLs()
+  }, [chainId, library, tokenPricesUSD, poolTvls])
+  return poolTvls
+}


### PR DESCRIPTION
1) guesstimate each pool's tvl in bulk using multicall in `usePoolsTVL`
2) pass this to `useCalculateSwapPairs` where it is used to sort pools in various places so that the highest tvl pool is listed first

This is kind of a patch job and in the future I'd like a cleaner, more central way of grabbing all pool info in bulk rather than having a hook for each pool.