### PR TITLE
Fix Deposit logic double-counting a token

### DIFF
--- a/src/pages/Deposit.tsx
+++ b/src/pages/Deposit.tsx
@@ -41,7 +41,9 @@ function Deposit({ poolName }: Props): ReactElement | null {
   const [poolData, userShareData] = usePoolData(poolName)
   const swapContract = useSwapContract(poolName)
   const allTokens = useMemo(() => {
-    return POOL.poolTokens.concat(POOL.underlyingPoolTokens || [])
+    return Array.from(
+      new Set(POOL.poolTokens.concat(POOL.underlyingPoolTokens || [])),
+    )
   }, [POOL.poolTokens, POOL.underlyingPoolTokens])
   const [tokenFormState, updateTokenFormState] = useTokenFormState(allTokens)
   const [shouldDepositWrapped, setShouldDepositWrapped] = useState(false)


### PR DESCRIPTION
When adding the concept to "underlying tokens", the frontend was accidentally counting one token twice (in this case susd since it was both a `token` and `underlying token`)

Resolves #574 

<img width="398" alt="Screen Shot 2021-08-03 at 12 26 24 PM" src="https://user-images.githubusercontent.com/7607886/128074348-8cdf433c-ef97-48c5-a736-785528224c0c.png">
