### PR TITLE
improve unit test coverage for utils

### DIFF
--- a/src/utils/__tests__/getEtherscanLink.ts
+++ b/src/utils/__tests__/getEtherscanLink.ts
@@ -1,0 +1,36 @@
+import { getEtherscanLink } from "../getEtherscanLink"
+
+describe("getEtherscanLink", () => {
+  it("returns the etherscan link for a tx", () => {
+    expect(
+      getEtherscanLink(
+        "0x1ce9355fc416959d57442a6a57c44b9a3fc9d700f7bbdbdba54c3b171f82140a",
+        "tx",
+      ),
+    ).toBe(
+      "https://etherscan.io/tx/0x1ce9355fc416959d57442a6a57c44b9a3fc9d700f7bbdbdba54c3b171f82140a",
+    )
+  })
+
+  it("returns the etherscan link for an address", () => {
+    expect(
+      getEtherscanLink("0xcd7587dd215ca6002c51f48c082af2d3fc77a6c5", "address"),
+    ).toBe(
+      "https://etherscan.io/address/0xcd7587dd215ca6002c51f48c082af2d3fc77a6c5",
+    )
+  })
+
+  it("returns the etherscan link for a block", () => {
+    expect(getEtherscanLink("12979165", "block")).toBe(
+      "https://etherscan.io/block/12979165",
+    )
+  })
+
+  it("returns the etherscan link for a token", () => {
+    expect(
+      getEtherscanLink("0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0", "token"),
+    ).toBe(
+      "https://etherscan.io/token/0x7d1afa7b718fb893db30a3abc0cfc608aacfebb0",
+    )
+  })
+})

--- a/src/utils/__tests__/shortenAddress.ts
+++ b/src/utils/__tests__/shortenAddress.ts
@@ -1,0 +1,19 @@
+import { shortenAddress } from "../shortenAddress"
+
+describe("shortenAddress", () => {
+  it("catches an error for a bad address", () => {
+    expect(() => shortenAddress("yo what up waleed")).toThrow(Error)
+  })
+
+  it("shortens address", () => {
+    expect(shortenAddress("0xcd7587dd215ca6002c51f48c082af2d3fc77a6ca")).toBe(
+      "0xcD75...A6cA",
+    )
+  })
+
+  it("shortens address", () => {
+    expect(
+      shortenAddress("0xcd7587dd215ca6002c51f48c082af2d3fc77a6ca", 5),
+    ).toBe("0xcD758...7A6cA")
+  })
+})


### PR DESCRIPTION
Adding tests to improve code coverage slowly for `/utils` directory. 

Improved the following coverage:
getEtherscanLink
shortenAddress


https://codecov.io/gh/saddle-finance/saddle-frontend/tree/master/src/utils