### PR TITLE
Change BTC pool status to be outdated.

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -637,6 +637,7 @@ export const POOLS_MAP: PoolsMap = {
     isSynthetic: true,
     type: PoolTypes.BTC,
     route: "btc",
+    isOutdated: true,
   },
   [BTC_POOL_V2_NAME]: {
     name: BTC_POOL_V2_NAME,


### PR DESCRIPTION
BTC pool is outdated after tBTC pool launching. Change its status to be outdated. 