### PR TITLE
Poll gas every 5s

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -81,7 +81,7 @@ function GasAndTokenPrices({
   const fetchAndUpdateSwapStats = useCallback(() => {
     void fetchSwapStats(dispatch)
   }, [dispatch])
-  usePoller(fetchAndUpdateGasPrice, BLOCK_TIME)
+  usePoller(fetchAndUpdateGasPrice, 5 * 1000)
   usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
   usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 280) // ~ 1hr
   return <>{children}</>


### PR DESCRIPTION
Since 1559 should be backwards compatible, maybe the baseFee is just changing faster than we're polling. Increase speed to test this idea. 