### PR TITLE
Allow notify to be run on unsupported chains

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -5,6 +5,7 @@ import { AppDispatch, AppState } from "../state"
 import { BLOCK_TIME, POOLS_MAP } from "../constants"
 import React, { ReactElement, Suspense, useCallback, useEffect } from "react"
 import { Route, Switch } from "react-router-dom"
+import { isChainSupportedByNotify, notify } from "../utils/notifyHandler"
 import { useDispatch, useSelector } from "react-redux"
 
 import Deposit from "./Deposit"
@@ -18,7 +19,6 @@ import Withdraw from "./Withdraw"
 import fetchGasPrices from "../utils/updateGasPrices"
 import fetchSwapStats from "../utils/getSwapStats"
 import fetchTokenPricesUSD from "../utils/updateTokenPrices"
-import { notify } from "../utils/notifyHandler"
 import { useActiveWeb3React } from "../hooks"
 import usePoller from "../hooks/usePoller"
 
@@ -28,7 +28,7 @@ export default function App(): ReactElement {
 
   useEffect(() => {
     notify?.config({
-      networkId: chainId ?? 1,
+      networkId: isChainSupportedByNotify(chainId) ? chainId : undefined,
       darkMode: userDarkMode,
     })
   }, [chainId, userDarkMode])

--- a/src/utils/notifyHandler.ts
+++ b/src/utils/notifyHandler.ts
@@ -3,16 +3,23 @@ import { getEtherscanLink } from "../utils/getEtherscanLink"
 import i18next from "i18next"
 
 const notifyNetworks = new Set([1, 3, 4, 5, 42, 56, 100])
-const networkId = parseInt(process.env.REACT_APP_CHAIN_ID ?? "1")
+const chainId = parseInt(process.env.REACT_APP_CHAIN_ID ?? "1")
 
 export const notify = Notify({
-  ...(notifyNetworks.has(networkId)
-    ? { dappId: process.env.REACT_APP_NOTIFY_DAPP_ID }
-    : {}), // trigger "UI Only Mode" when on a testnet https://docs.blocknative.com/notify#ui-only-mode
-  networkId,
+  ...(isChainSupportedByNotify(chainId)
+    ? {
+        dappId: process.env.REACT_APP_NOTIFY_DAPP_ID,
+        networkId: chainId,
+      }
+    : {}),
   desktopPosition: "topRight" as const,
   darkMode: false,
 })
+
+export function isChainSupportedByNotify(chainId: number | undefined): boolean {
+  if (!chainId) return false
+  return notifyNetworks.has(chainId)
+}
 
 export function notifyHandler(
   hash: string,


### PR DESCRIPTION
Passing valid `dappId` or `networkId` config will trigger notify to look for both configs.
This commit changes so when using unsupported networks, we dont pass either configs.