### PR TITLE
Implement hook to add token to metamask

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,6 @@
+
 {
-  "extends":  [
+  "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended",
     "plugin:@typescript-eslint/recommended-requiring-type-checking",
@@ -12,9 +13,9 @@
       "version": "detect" // Tells eslint-plugin-react to automatically detect the version of React to use
     }
   },
-  "parser":  "@typescript-eslint/parser",
+  "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "ecmaVersion":  2018,
+    "ecmaVersion": 2018,
     "project": ["./tsconfig.json", "./cypress/tsconfig.json"],
     "sourceType": "module"
   },
@@ -28,6 +29,7 @@
   },
   "rules": {
     "@typescript-eslint/no-unused-vars": ["error"],
+    "@typescript-eslint/ban-ts-comment": "off",
     "no-invalid-this": 0,
     "no-unused-vars": "off",
     "sort-imports": "error"

--- a/src/hooks/useAddTokenToMetamask.ts
+++ b/src/hooks/useAddTokenToMetamask.ts
@@ -33,7 +33,7 @@ export default function useAddTokenToMetamask(
         .then((success) => setSuccess(success))
         .catch(() => setSuccess(false))
     }
-  }, [library, token])
+  }, [library, token, chainId, isMetaMask])
 
   return { addToken, success }
 }

--- a/src/hooks/useAddTokenToMetamask.ts
+++ b/src/hooks/useAddTokenToMetamask.ts
@@ -1,0 +1,39 @@
+import { SUPPORTED_WALLETS, Token } from "../constants"
+import { useCallback, useState } from "react"
+import { find } from "lodash"
+import { useActiveWeb3React } from "./index"
+
+export default function useAddTokenToMetamask(
+  token: Token | undefined,
+): {
+  addToken: () => void
+  success: boolean | undefined
+} {
+  const { library, chainId, connector } = useActiveWeb3React()
+  const [success, setSuccess] = useState<boolean | undefined>()
+
+  const isMetaMask: boolean =
+    find(SUPPORTED_WALLETS, ["connector", connector])?.name == "MetaMask"
+
+  const addToken = useCallback(() => {
+    if (library && library.provider.request && isMetaMask && token && chainId) {
+      library.provider
+        .request({
+          method: "wallet_watchAsset",
+          params: {
+            //@ts-ignore // need this for incorrect ethers provider type
+            type: "ERC20",
+            options: {
+              address: token.addresses[chainId],
+              symbol: token.symbol,
+              decimals: token.decimals,
+            },
+          },
+        })
+        .then((success) => setSuccess(success))
+        .catch(() => setSuccess(false))
+    }
+  }, [library, token])
+
+  return { addToken, success }
+}


### PR DESCRIPTION
Implement hook to add Token to MetaMask. This hook is generic for any `Token` obj.

I've left out the `image` parameter for now

As there's no UI element currently using this functionality, I tested manually by adding a dummy button & couple of tokens (`STABLECOIN_SWAP_TOKEN` and `TBTC_SWAP_TOKEN`)

The `.eslintrc` is for the `@ts-ignore` that we need as ethers returns an incorrect type


<img width="932" alt="Screen Shot 2021-09-23 at 4 37 06 PM" src="https://user-images.githubusercontent.com/3933447/134597850-f666ad69-478d-4116-8e9b-201f54a5bc8f.png">

<img width="355" alt="Screen Shot 2021-09-23 at 4 37 16 PM" src="https://user-images.githubusercontent.com/3933447/134597855-e82fc60d-50b7-49d9-9c1a-bbb3319fe863.png">

