### PR TITLE
Correct price impact math for withdraws

### DIFF
--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -60,7 +60,7 @@ function Withdraw({ poolName }: Props): ReactElement {
               sum + (+withdrawFormState.tokenInputs[symbol].valueRaw || 0),
             0,
           )
-          .toFixed(18),
+          .toString(),
         18,
       )
       let withdrawLPTokenAmount
@@ -90,6 +90,7 @@ function Withdraw({ poolName }: Props): ReactElement {
           withdrawLPTokenAmount,
           tokenInputSum,
           poolData.virtualPrice,
+          true,
         ),
       )
     }

--- a/src/utils/__tests__/priceImpact.ts
+++ b/src/utils/__tests__/priceImpact.ts
@@ -39,6 +39,30 @@ describe("calculatePriceImpact", () => {
       ),
     ).toEqual(parseUnits("-.5", 18))
   })
+
+  it("correctly calculates value for negative imbalanced withdraw", () => {
+    // 9 / 10 * 1.01 - 1 = -0.10891089108910891
+    expect(
+      calculatePriceImpact(
+        parseUnits("10", 18), // give 10 lpTokens
+        parseUnits("9", 18), // receive 9 pool tokens
+        parseUnits("1.01", 18),
+        true,
+      ),
+    ).toEqual(parseUnits("-.108910891089108911", 18))
+  })
+
+  it("correctly calculates value for posiive imbalanced withdraw", () => {
+    // 11 / 10 * 1.01 - 1 = .089108910
+    expect(
+      calculatePriceImpact(
+        parseUnits("10", 18), // give 10 lpTokens
+        parseUnits("11", 18), // receive 9 pool tokens
+        parseUnits("1.01", 18),
+        true,
+      ),
+    ).toEqual(parseUnits("0.089108910891089108", 18))
+  })
 })
 
 describe("isHighPriceImpact", () => {

--- a/src/utils/priceImpact.ts
+++ b/src/utils/priceImpact.ts
@@ -1,5 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { Zero } from "@ethersproject/constants"
+
 export function isHighPriceImpact(priceImpact: BigNumber): boolean {
   // assumes that priceImpact has 18d precision
   const negOne = BigNumber.from(10)
@@ -12,11 +13,21 @@ export function calculatePriceImpact(
   tokenInputAmount: BigNumber, // assumed to be 18d precision
   tokenOutputAmount: BigNumber,
   virtualPrice = BigNumber.from(10).pow(18),
+  isWithdraw = false,
 ): BigNumber {
-  return tokenInputAmount.gt(0)
-    ? virtualPrice
+  // We want to multiply the lpTokenAmount by virtual price
+  // Deposits: (VP * output) / input - 1
+  // Swaps: (1 * output) / input - 1
+  // Withdraws: output / (input * VP) - 1
+  if (tokenInputAmount.lte(0)) return Zero
+
+  return isWithdraw
+    ? tokenOutputAmount
+        .mul(BigNumber.from(10).pow(36))
+        .div(tokenInputAmount.mul(virtualPrice))
+        .sub(BigNumber.from(10).pow(18))
+    : virtualPrice
         .mul(tokenOutputAmount)
         .div(tokenInputAmount)
         .sub(BigNumber.from(10).pow(18))
-    : Zero
 }


### PR DESCRIPTION
Previously we were doing `(VP * output) / input - 1` for both deposits and withdraws. Now we still use that for deposits but instead use `output / (input * VP) - 1` for withdraws since the input is an lpToken