### PR TITLE
Fix the virtual swap wrong link issue

### DIFF
--- a/src/components/PendingSwapModal.tsx
+++ b/src/components/PendingSwapModal.tsx
@@ -222,7 +222,7 @@ const PendingSwapModal = ({
             <div className={styles.about}>
               <InfoIcon />
               <a
-                href="https://docs.saddle.finance/faq#what-is-virtual-swap"
+                href="https://docs.saddle.finance/saddle-faq#what-is-virtual-swap"
                 target="_blank"
                 rel="noreferrer"
               >

--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -203,7 +203,7 @@ const SwapPage = (props: Props): ReactElement => {
                   <span></span>
                   <span>
                     <a
-                      href="https://docs.saddle.finance/faq#what-is-virtual-swap"
+                      href="https://docs.saddle.finance/saddle-faq#what-is-virtual-swap"
                       style={{ textDecoration: "underline" }}
                       target="_blank"
                       rel="noreferrer"
@@ -233,7 +233,7 @@ const SwapPage = (props: Props): ReactElement => {
             <InfoIcon />
             {t("crossAssetSwapsUseVirtualSwaps")} {"<"}
             <a
-              href="https://docs.saddle.finance/faq#what-is-virtual-swap"
+              href="https://docs.saddle.finance/saddle-faq#what-is-virtual-swap"
               target="_blank"
               rel="noreferrer"
             >


### PR DESCRIPTION
Current virtual swap's learn more notification links to the wrong url. Replace it with the correct one in Saddle FAQ page. 

Close #666 