### PR TITLE
Create Tag component for SearchSelect and PoolOverview

### DIFF
--- a/src/components/PoolOverview.scss
+++ b/src/components/PoolOverview.scss
@@ -139,22 +139,6 @@ div.outdated {
   border-color: $yellow2;
 }
 
-.tag {
-  border-radius: 4px;
-  font-size: 20px;
-  font-weight: $bold;
-  align-self: center;
-  padding: 2px 4px;
-}
-.tag.warning {
-  border: 1px solid $yellow2;
-  color: $yellow2;
-}
-.tag.error {
-  border: 1px solid $error;
-  color: $error;
-}
-
 div.poolOverview:first-child {
   margin-top: 0;
 }

--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -11,6 +11,7 @@ import {
 
 import Button from "./Button"
 import { Link } from "react-router-dom"
+import Tag from "./Tag"
 import ToolTip from "./ToolTip"
 import { Zero } from "@ethersproject/constants"
 import classNames from "classnames"
@@ -76,8 +77,16 @@ export default function PoolOverview({
       <div className="left">
         <div className="titleAndTag">
           <h4 className="title">{formattedData.name}</h4>
-          {(shouldMigrate || isOutdated) && <Tag kind="warning">OUTDATED</Tag>}
-          {poolData.isPaused && <Tag kind="error">PAUSED</Tag>}
+          {(shouldMigrate || isOutdated) && (
+            <Tag kind="warning" size="large">
+              OUTDATED
+            </Tag>
+          )}
+          {poolData.isPaused && (
+            <Tag kind="error" size="large">
+              PAUSED
+            </Tag>
+          )}
         </div>
         {hasShare && (
           <div className="balance">
@@ -161,12 +170,4 @@ export default function PoolOverview({
       </div>
     </div>
   )
-}
-
-function Tag(props: {
-  children?: React.ReactNode
-  kind?: "warning" | "error"
-}) {
-  const { kind = "warning", ...tagProps } = props
-  return <span className={classNames("tag", kind)} {...tagProps} />
 }

--- a/src/components/SearchSelect.module.scss
+++ b/src/components/SearchSelect.module.scss
@@ -94,25 +94,5 @@
 .tagWrapper {
   display: flex;
   align-items: center;
-  > .unavailableTag,
-  .virtualSwapTag {
-    border: 1px solid var(--text-lightest);
-    border-radius: 4px;
-    padding: 1px 2px;
-    font-weight: 700;
-    font-size: 11px;
-    display: inline-block;
-    margin-left: 8px;
-    line-height: 14px;
-  }
-}
-
-.unavailableTag {
-  color: var(--text-lightest);
-  border: 1px solid var(--text-lightest);
-}
-
-.virtualSwapTag {
-  color: $primary;
-  border: 1px solid var(--outline);
+  gap: 8px;
 }

--- a/src/components/SearchSelect.tsx
+++ b/src/components/SearchSelect.tsx
@@ -8,6 +8,7 @@ import React, {
 
 import Divider from "./Divider"
 import { SWAP_TYPES } from "../constants"
+import Tag from "./Tag"
 import type { TokenOption } from "../pages/Swap"
 import classnames from "classnames"
 import { commify } from "../utils"
@@ -155,10 +156,14 @@ function ListItem({
         <div className={styles.tagWrapper}>
           <b>{symbol}</b>
           {!isAvailable && (
-            <span className={styles.unavailableTag}>{t("unavailable")}</span>
+            <Tag size="small" kind="disabled">
+              {t("unavailable")}
+            </Tag>
           )}
           {isAvailable && isVirtualSwap && (
-            <span className={styles.virtualSwapTag}>{t("virtualSwap")}</span>
+            <Tag size="small" kind="primary">
+              {t("virtualSwap")}
+            </Tag>
           )}
         </div>
         <p className={styles.textMinor}>{name}</p>

--- a/src/components/Tag.module.scss
+++ b/src/components/Tag.module.scss
@@ -1,0 +1,35 @@
+@import "../styles/theme";
+
+.large {
+  border-radius: 4px;
+  font-size: 20px;
+  font-weight: $bold;
+  align-self: center;
+  padding: 2px 4px;
+}
+.warning {
+  border: 1px solid $yellow2;
+  color: $yellow2;
+}
+.error {
+  border: 1px solid $error;
+  color: $error;
+}
+.small {
+  border-radius: 4px;
+  padding: 1px 2px;
+  font-weight: 700;
+  font-size: 12px;
+  align-self: center;
+  display: inline-block;
+  line-height: 16px;
+}
+.disabled {
+  color: var(--text-lightest);
+  border: 1px solid var(--text-lightest);
+}
+
+.primary {
+  color: var(--text-primary);
+  border: 1px solid var(--text-primary);
+}

--- a/src/components/Tag.tsx
+++ b/src/components/Tag.tsx
@@ -1,0 +1,20 @@
+import React, { ReactElement } from "react"
+import classNames from "classnames"
+import styles from "./Tag.module.scss"
+
+type Props = {
+  size: "small" | "large"
+  kind: "disabled" | "primary" | "error" | "warning"
+}
+
+export default function Tag(
+  props: React.PropsWithChildren<Props>,
+): ReactElement {
+  const { size, kind, ...tagProps } = props
+  return (
+    <span
+      className={classNames(styles.tag, styles[kind], styles[size])}
+      {...tagProps}
+    />
+  )
+}


### PR DESCRIPTION
Currently both SearchSelect and PoolOverview uses tags with local styling. We may use tag in other components in the future as well. So it's worth to have Tag to be a component. 

* Create Tag component
* Migrate SearchSelect and PoolOverview tags with Tag component

Vlose #588 