### PR TITLE
Deprecate GasNow and use POA temporarily to fetch gas prices

### DIFF
--- a/src/utils/updateGasPrices.ts
+++ b/src/utils/updateGasPrices.ts
@@ -14,14 +14,6 @@ interface POAGasResponse {
   health: boolean
 }
 
-interface GasNowGasResponse {
-  code: number
-  data: {
-    rapid: number
-    fast: number
-    standard: number
-  }
-}
 const fetchGasPricePOA = (): Promise<GenericGasReponse> =>
   fetch("https://gasprice.poa.network/")
     .then((res) => res.json())
@@ -37,24 +29,6 @@ const fetchGasPricePOA = (): Promise<GenericGasReponse> =>
       throw new Error("Unable to fetch gas price from POA Network")
     })
 
-const fetchGasPriceGasNow = (): Promise<GenericGasReponse> =>
-  fetch("https://www.gasnow.org/api/v3/gas/price?utm_source=saddle")
-    .then((res) => res.json())
-    .then((body: GasNowGasResponse) => {
-      const {
-        code,
-        data: { rapid, fast, standard },
-      } = body
-      if (code >= 200 && code < 300) {
-        return {
-          gasStandard: Math.round(standard / 1e9),
-          gasFast: Math.round(fast / 1e9),
-          gasInstant: Math.round(rapid / 1e9),
-        }
-      }
-      throw new Error("Unable to fetch gas price from GasNow Network")
-    })
-
 export default async function fetchGasPrices(
   dispatch: AppDispatch,
 ): Promise<void> {
@@ -63,7 +37,7 @@ export default async function fetchGasPrices(
   }
   await retry(
     () =>
-      fetchGasPriceGasNow() // try gaspricenow first
+      fetchGasPricePOA()
         .then(dispatchUpdate)
         .catch(() => fetchGasPricePOA().then(dispatchUpdate)), // else fall back to poa before retrying
     {


### PR DESCRIPTION
The plan is to switch to POA for now since Gasnow is going away tomorrow, then switch to a more 1559-compliant provider soon