### PR TITLE
first pass at removing gas

### DIFF
--- a/src/components/AdvancedOptions.tsx
+++ b/src/components/AdvancedOptions.tsx
@@ -190,7 +190,7 @@ export default function AdvancedOptions(): ReactElement {
             </div>
           </div>
         </div>
-        <div className={styles.parameter}>
+        <div className={styles.parameter} style={{ display: "none" }}>
           <div className={styles.inputGroup}>
             <div className={styles.options}>
               <div className={styles.label}>{t("gas")}:</div>

--- a/src/components/PendingSwapModal.tsx
+++ b/src/components/PendingSwapModal.tsx
@@ -95,6 +95,7 @@ const PendingSwapModal = ({
     void calcAmount()
   }, [bridgeContract, settlementState, itemId, swapType])
 
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const gasPrice = gasBNFromState(
     { gasStandard, gasFast, gasInstant },
     gasPriceSelected,
@@ -114,7 +115,7 @@ const PendingSwapModal = ({
   const handleConfirmSettlement = useCallback(async () => {
     try {
       setCurrentStep("confirmation")
-      const txnArgs = { gasPrice }
+      const txnArgs = {}
       let transaction
       if (settlementState.action === "withdraw") {
         transaction = await bridgeContract?.withdraw(
@@ -172,7 +173,6 @@ const PendingSwapModal = ({
     bridgeContract,
     itemId,
     calculatedTokenAmount,
-    gasPrice,
     onClose,
     slippageCustom,
     slippageSelected,

--- a/src/hooks/useApproveAndDeposit.ts
+++ b/src/hooks/useApproveAndDeposit.ts
@@ -170,9 +170,6 @@ export function useApproveAndDeposit(
           minToMint,
           txnDeadline,
           [],
-          {
-            gasPrice,
-          },
         )
       } else {
         const swapFlashLoanContract = effectiveSwapContract as SwapFlashLoan
@@ -180,9 +177,6 @@ export function useApproveAndDeposit(
           txnAmounts,
           minToMint,
           txnDeadline,
-          {
-            gasPrice,
-          },
         )
       }
 

--- a/src/hooks/useApproveAndMigrateUSD.ts
+++ b/src/hooks/useApproveAndMigrateUSD.ts
@@ -55,9 +55,6 @@ export function useApproveAndMigrateUSD(): (
       const migrateTransaction = await migratorContract.migrateUSDPool(
         lpTokenBalance,
         lpTokenBalance.mul(1000 - 5).div(1000), // 50bps, 0.5%
-        {
-          gasPrice,
-        },
       )
 
       notifyHandler(migrateTransaction.hash, "migrate")

--- a/src/hooks/useApproveAndSwap.ts
+++ b/src/hooks/useApproveAndSwap.ts
@@ -89,7 +89,7 @@ export function useApproveAndSwap(): (
       } else {
         gasPrice = gasStandard
       }
-      gasPrice = parseUnits(String(gasPrice) || "45", 9)
+      gasPrice = parseUnits(gasPrice ? String(gasPrice) : "45", 9)
       if (tokenContract == null) return
       let addressToApprove = ""
       if (state.swapType === SWAP_TYPES.DIRECT) {
@@ -112,7 +112,6 @@ export function useApproveAndSwap(): (
           },
         },
       )
-      const txnArgs = { gasPrice }
       let swapTransaction
       if (state.swapType === SWAP_TYPES.TOKEN_TO_TOKEN) {
         const originPool = POOLS_MAP[state.from.poolName]
@@ -130,7 +129,6 @@ export function useApproveAndSwap(): (
             slippageSelected,
             slippageCustom,
           ), // subtract slippage from minSynth
-          txnArgs,
         ] as const
         console.debug("swap - tokenToToken", args)
         swapTransaction = await (state.bridgeContract as Bridge).tokenToToken(
@@ -148,7 +146,6 @@ export function useApproveAndSwap(): (
             slippageSelected,
             slippageCustom,
           ), // subtract slippage from minSynth
-          txnArgs,
         ] as const
         console.debug("swap - synthToToken", args)
         swapTransaction = await (state.bridgeContract as Bridge).synthToToken(
@@ -162,7 +159,6 @@ export function useApproveAndSwap(): (
           utils.formatBytes32String(state.to.symbol),
           state.from.amount,
           subtractSlippage(state.to.amount, slippageSelected, slippageCustom),
-          txnArgs,
         ] as const
         console.debug("swap - tokenToSynth", args)
         swapTransaction = await (state.bridgeContract as Bridge).tokenToSynth(
@@ -179,7 +175,6 @@ export function useApproveAndSwap(): (
           state.from.amount,
           subtractSlippage(state.to.amount, slippageSelected, slippageCustom),
           Math.round(new Date().getTime() / 1000 + 60 * deadline),
-          txnArgs,
         ] as const
         console.debug("swap - direct", args)
         swapTransaction = await (state.swapContract as NonNullable<

--- a/src/hooks/useApproveAndWithdraw.ts
+++ b/src/hooks/useApproveAndWithdraw.ts
@@ -3,6 +3,7 @@ import { addSlippage, subtractSlippage } from "../utils/slippage"
 import { formatUnits, parseUnits } from "@ethersproject/units"
 import { notifyCustomError, notifyHandler } from "../utils/notifyHandler"
 import { useLPTokenContract, useSwapContract } from "./useContract"
+
 import { AppState } from "../state"
 import { BigNumber } from "@ethersproject/bignumber"
 import { GasPrices } from "../state/user"
@@ -105,9 +106,6 @@ export function useApproveAndWithdraw(
             ),
           ),
           deadline,
-          {
-            gasPrice,
-          },
         )
       } else if (state.withdrawType === "IMBALANCE") {
         spendTransaction = await swapContract.removeLiquidityImbalance(
@@ -120,9 +118,6 @@ export function useApproveAndWithdraw(
             slippageCustom,
           ),
           deadline,
-          {
-            gasPrice,
-          },
         )
       } else {
         // state.withdrawType === [TokenSymbol]
@@ -139,9 +134,6 @@ export function useApproveAndWithdraw(
             slippageCustom,
           ),
           deadline,
-          {
-            gasPrice,
-          },
         )
       }
 

--- a/src/utils/checkAndApproveTokenForTrade.ts
+++ b/src/utils/checkAndApproveTokenForTrade.ts
@@ -26,7 +26,8 @@ export default async function checkAndApproveTokenForTrade(
   spenderAddress: string,
   spendingValue: BigNumber, // max is MaxUint256
   infiniteApproval = false,
-  gasPrice: BigNumber,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  gasPrice: BigNumber, // @dev unused
   callbacks: {
     onTransactionStart?: (
       transaction?: ContractTransaction,
@@ -53,9 +54,6 @@ export default async function checkAndApproveTokenForTrade(
       const approvalTransaction = await srcTokenContract.approve(
         swapAddress,
         amount,
-        {
-          gasPrice,
-        },
       )
       // Add notification
       notifyHandler(approvalTransaction.hash, "tokenApproval")

--- a/src/utils/updateGasPrices.ts
+++ b/src/utils/updateGasPrices.ts
@@ -1,6 +1,4 @@
 import { AppDispatch } from "../state"
-import retry from "async-retry"
-import { updateGasPrices } from "../state/application"
 
 interface GenericGasReponse {
   gasStandard: number
@@ -13,6 +11,7 @@ interface POAGasResponse {
   fast: number
 }
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const fetchGasPricePOA = (): Promise<GenericGasReponse> =>
   fetch("https://blockscout.com/eth/mainnet/api/v1/gas-price-oracle")
     .then((res) => res.json())
@@ -27,18 +26,20 @@ const fetchGasPricePOA = (): Promise<GenericGasReponse> =>
     })
 
 export default async function fetchGasPrices(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   dispatch: AppDispatch,
 ): Promise<void> {
-  const dispatchUpdate = (gasPrices: GenericGasReponse) => {
-    dispatch(updateGasPrices(gasPrices))
-  }
-  await retry(
-    () =>
-      fetchGasPricePOA()
-        .then(dispatchUpdate)
-        .catch(() => fetchGasPricePOA().then(dispatchUpdate)), // else fall back to poa before retrying
-    {
-      retries: 3,
-    },
-  )
+  return Promise.resolve()
+  // const dispatchUpdate = (gasPrices: GenericGasReponse) => {
+  //   dispatch(updateGasPrices(gasPrices))
+  // }
+  // await retry(
+  //   () =>
+  //     fetchGasPricePOA()
+  //       .then(dispatchUpdate)
+  //       .catch(() => fetchGasPricePOA().then(dispatchUpdate)), // else fall back to poa before retrying
+  //   {
+  //     retries: 3,
+  //   },
+  // )
 }


### PR DESCRIPTION
Gas fetching seems to be broken, which breaks transactions. We aim to remove gas fetching and setting, instead relying on the user's wallet to set gas. This is what Uniswap does.

- noops the fetching of gasprice from the network
- hides gasprice from advanced options
- removes gasprice from all contract interactions (please double check)

NOTE - gas data is still shown in the txn review modals, these should be removed as well for completion  