### PR TITLE
Hide SDL reward button on non-hardhat / mainnet networks

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -1,9 +1,9 @@
 import "./TopMenu.scss"
 
+import { ChainId, IS_SDL_LIVE } from "../constants"
 import React, { ReactElement, useContext, useRef, useState } from "react"
 
 import Button from "./Button"
-import { IS_SDL_LIVE } from "../constants"
 import { Link } from "react-router-dom"
 import Modal from "./Modal"
 import NetworkDisplay from "./NetworkDisplay"
@@ -14,6 +14,7 @@ import Web3Status from "./Web3Status"
 import classNames from "classnames"
 import { formatBNToShortString } from "../utils"
 import logo from "../assets/icons/logo.svg"
+import { useActiveWeb3React } from "../hooks"
 import useDetectOutsideClick from "../hooks/useDetectOutsideClick"
 import { useTranslation } from "react-i18next"
 
@@ -24,6 +25,9 @@ interface Props {
 function TopMenu({ activeTab }: Props): ReactElement {
   const { t } = useTranslation()
   const [currentModal, setCurrentModal] = useState<string | null>(null)
+  const { chainId } = useActiveWeb3React()
+  const showRewardButton: boolean =
+    chainId === ChainId.MAINNET || chainId === ChainId.HARDHAT
 
   return (
     <header
@@ -70,7 +74,10 @@ function TopMenu({ activeTab }: Props): ReactElement {
         </li>
       </ul>
       <div className="walletWrapper">
-        <RewardsButton setCurrentModal={setCurrentModal} />
+        {showRewardButton && (
+          <RewardsButton setCurrentModal={setCurrentModal} />
+        )}
+
         <Web3Status />
         <NetworkDisplayAndSettings />
         <IconButtonAndSettings />


### PR DESCRIPTION
## What does this PR do?

Simply hide the SDL button in the nav on non-hardhat / mainnet networks

## Context

#737 

## Screenshot
![Screen Shot 2021-12-21 at 12 43 25 AM](https://user-images.githubusercontent.com/75422800/146842432-6241e535-80a2-495d-b561-8546d7826045.png)
![Screen Shot 2021-12-21 at 12 43 42 AM](https://user-images.githubusercontent.com/75422800/146842459-425c7aa1-54a0-4d37-b369-
![Screen Shot 2021-12-21 at 12 43 54 AM](https://user-images.githubusercontent.com/75422800/146842479-4d910ebd-fd35-44ff-aaae-2a56c74b3f26.png)
19f045ff9f90.png)

