### PR TITLE
use correct pool address when getting meta pool apys

### DIFF
--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -306,9 +306,11 @@ export default function usePoolData(
           value: userPoolTokenBalances[i],
         }))
         const poolAddress = POOL.addresses[chainId].toLowerCase()
+        const metaSwapAddress = POOL.metaSwapAddresses?.[chainId]?.toLowerCase()
+        const underlyingPool = metaSwapAddress || poolAddress
         const { oneDayVolume, apy, utilization } =
-          swapStats && poolAddress in swapStats
-            ? swapStats[poolAddress]
+          swapStats && underlyingPool in swapStats
+            ? swapStats[underlyingPool]
             : { oneDayVolume: null, apy: null, utilization: null }
 
         let sdlPerDay = null
@@ -330,13 +332,11 @@ export default function usePoolData(
             .div(totalAllocPoint)
         }
 
-        const metaSwapAddress = POOL.metaSwapAddresses?.[chainId]
-        const poolAddressToCheckMigrationStatus = metaSwapAddress || poolAddress
         let isMigrated = false
-        if (poolAddressToCheckMigrationStatus && migratorContract) {
+        if (underlyingPool && migratorContract) {
           try {
             const migrationMapRes = await migratorContract.migrationMap(
-              poolAddressToCheckMigrationStatus,
+              underlyingPool,
             )
             isMigrated = migrationMapRes.newPoolAddress !== AddressZero
           } catch (err) {


### PR DESCRIPTION
We were previously trying to get APYs from the `pool-stats` response using the MetaSwapDeposit address rather than just the swap address.

After
<img width="917" alt="Screen Shot 2022-01-06 at 2 02 39 PM" src="https://user-images.githubusercontent.com/7607886/148458505-7e78f6c0-4337-44e4-8ed1-af4f42f4543c.png">

Before
<img width="905" alt="Screen Shot 2022-01-06 at 2 03 00 PM" src="https://user-images.githubusercontent.com/7607886/148458540-8f667b5e-5489-42ee-9a9c-1fb5e79ed823.png">
 