### PR TITLE
Fix: layout fix on small screen

### DIFF
--- a/src/components/SwapPage.tsx
+++ b/src/components/SwapPage.tsx
@@ -108,7 +108,7 @@ const SwapPage = (props: Props): ReactElement => {
       parseFloat(slippageCustom?.valueRaw || "0") < 0.5)
 
   return (
-    <Container maxWidth="sm" sx={{ mt: 5, mb: 20 }}>
+    <Container maxWidth="sm" sx={{ pt: 5, pb: 20 }}>
       <div className="swapPage">
         <Paper>
           <Box p={{ xs: 3, md: 4 }} flex={1}>


### PR DESCRIPTION
## What does this PR do?

There is a spacing under the bottom of  `swap` page.

![image](https://user-images.githubusercontent.com/75422800/159076078-eec1a34e-e72e-4b4e-95c5-e5d2e8607c18.png)

This is appearing on small screen which the screen height is less than the height of  swap form .