### PR TITLE
simplified Deposit e2e flow, asserting tx succ and value change

### DIFF
--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -1,9 +1,6 @@
 import { PoolName } from "../../src/constants"
 
-const poolTokens: { [key: string]: string[] } = {
-  "BTC V2": ["WBTC", "RENBTC", "sBTC"],
-  "Stablecoin V2": ["DAI", "USDC", "USDT"],
-}
+const pools = ["BTC V2", "Stablecoin V2"]
 
 context("Deposit Flow", () => {
   beforeEach(() => {
@@ -11,28 +8,14 @@ context("Deposit Flow", () => {
     cy.visit(`${host}#/pools`)
     cy.wait(3000)
   })
+
   function testPoolDeposit(poolName: PoolName) {
     it(`successfully completes a deposit of all ${poolName} assets`, () => {
-      let beforeValue: { [key: string]: number } = {}
       cy.contains(poolName)
         .parents("[data-testid=poolOverview]")
         .within(() => {
           cy.get("button").contains("Deposit").click()
         })
-      // attempt to wait for pool data to load
-      cy.get("input").first({ timeout: 10000 }).should("be.enabled")
-      // TODO: assert default state of the page
-      // Get before value of each token in My Share section
-      poolTokens[poolName].forEach((token: string) => {
-        cy.get("[data-testid=tokenName]")
-          .contains(token)
-          .parent()
-          .find("[data-testid=tokenValue]")
-          .then(($value) => {
-            beforeValue = { ...beforeValue, [token]: parseFloat($value.text()) }
-          })
-      })
-
       cy.get("#tokenInput input").then(($inputs) => {
         cy.wrap($inputs).each(($input) => {
           cy.wrap($input).type("1")
@@ -43,37 +26,15 @@ context("Deposit Flow", () => {
           .then(($value) => {
             prevVal = $value.text()
           })
-        // TODO: assert price impact changes
-        cy.wait(500)
-        // click "deposit" to trigger review modal
         cy.get("button").contains("Deposit").first().click()
-        // TODO: assert review data
-        // click "confirm" to initiate the actual transactions
         cy.get("button").contains("Confirm Deposit").click()
-        // Wait and assert after value of each token has been increased by 1
-        // poolTokens[poolName].forEach((token: string) => {
         cy.get(".Toastify").contains(`Deposit on ${poolName} complete`)
-        // cy.log("token", token)
-        // cy.get("[data-testid=tokenValue]")
-        //   .first()
-        //   .then(($value) => {
-        //     const prevVal = $value.text()
-        // cy.get("button").contains("Confirm Withdraw").click()
         cy.get("[data-testid=tokenValue]")
           .first()
           .should("not.have.text", prevVal)
-        // })
-        // cy.get("[data-testid=tokenName]")
-        //   .contains(token)
-        //   .parent()
-        //   .find("[data-testid=tokenValue]")
-        //   .then(($value) => {
-        //     const afterValue = parseFloat($value.text())
-        //     expect(afterValue).to.eq(beforeValue[token] + 1)
-        //   })
-        // })
       })
     })
   }
-  ;["BTC V2", "Stablecoin V2"].forEach(testPoolDeposit)
+
+  pools.forEach(testPoolDeposit)
 })

--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -29,7 +29,7 @@ context("Deposit Flow", () => {
           .parent()
           .find("[data-testid=tokenValue]")
           .then(($value) => {
-            beforeValue = { ...beforeValue, [token]: parseInt($value.text()) }
+            beforeValue = { ...beforeValue, [token]: parseFloat($value.text()) }
           })
       })
 
@@ -37,6 +37,12 @@ context("Deposit Flow", () => {
         cy.wrap($inputs).each(($input) => {
           cy.wrap($input).type("1")
         })
+        let prevVal: string
+        cy.get("[data-testid=tokenValue]")
+          .first()
+          .then(($value) => {
+            prevVal = $value.text()
+          })
         // TODO: assert price impact changes
         cy.wait(500)
         // click "deposit" to trigger review modal
@@ -45,19 +51,27 @@ context("Deposit Flow", () => {
         // click "confirm" to initiate the actual transactions
         cy.get("button").contains("Confirm Deposit").click()
         // Wait and assert after value of each token has been increased by 1
-        cy.wait(10000).then(() => {
-          poolTokens[poolName].forEach((token: string) => {
-            cy.log("token", token)
-            cy.get("[data-testid=tokenName]")
-              .contains(token)
-              .parent()
-              .find("[data-testid=tokenValue]")
-              .then(($value) => {
-                const afterValue = parseInt($value.text())
-                expect(afterValue).to.eq(beforeValue[token] + 1)
-              })
-          })
-        })
+        // poolTokens[poolName].forEach((token: string) => {
+        cy.get(".Toastify").contains(`Deposit on ${poolName} complete`)
+        // cy.log("token", token)
+        // cy.get("[data-testid=tokenValue]")
+        //   .first()
+        //   .then(($value) => {
+        //     const prevVal = $value.text()
+        // cy.get("button").contains("Confirm Withdraw").click()
+        cy.get("[data-testid=tokenValue]")
+          .first()
+          .should("not.have.text", prevVal)
+        // })
+        // cy.get("[data-testid=tokenName]")
+        //   .contains(token)
+        //   .parent()
+        //   .find("[data-testid=tokenValue]")
+        //   .then(($value) => {
+        //     const afterValue = parseFloat($value.text())
+        //     expect(afterValue).to.eq(beforeValue[token] + 1)
+        //   })
+        // })
       })
     })
   }

--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -25,11 +25,9 @@ context("Deposit Flow", () => {
         .first()
         .then(($value) => {
           const prevVal = $value.text()
-          cy.log("prevVale", prevVal)
           cy.get("button").contains("Deposit").first().click()
           cy.get("button").contains("Confirm Deposit").click()
           cy.get(".Toastify").contains(`Deposit on ${poolName} complete`)
-          cy.log("prevVale", prevVal)
           cy.get("[data-testid=tokenValue]")
             .first()
             .should("not.have.text", prevVal)

--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -20,19 +20,20 @@ context("Deposit Flow", () => {
         cy.wrap($inputs).each(($input) => {
           cy.wrap($input).type("1")
         })
-        let prevVal: string
-        cy.get("[data-testid=tokenValue]")
-          .first()
-          .then(($value) => {
-            prevVal = $value.text()
-          })
-        cy.get("button").contains("Deposit").first().click()
-        cy.get("button").contains("Confirm Deposit").click()
-        cy.get(".Toastify").contains(`Deposit on ${poolName} complete`)
-        cy.get("[data-testid=tokenValue]")
-          .first()
-          .should("not.have.text", prevVal)
       })
+      cy.get("[data-testid=tokenValue]")
+        .first()
+        .then(($value) => {
+          const prevVal = $value.text()
+          cy.log("prevVale", prevVal)
+          cy.get("button").contains("Deposit").first().click()
+          cy.get("button").contains("Confirm Deposit").click()
+          cy.get(".Toastify").contains(`Deposit on ${poolName} complete`)
+          cy.log("prevVale", prevVal)
+          cy.get("[data-testid=tokenValue]")
+            .first()
+            .should("not.have.text", prevVal)
+        })
     })
   }
 

--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -243,6 +243,7 @@
   "basepool": "Base Pool",
   "unstakeComplete": "Unstake on {{poolName}} complete",
   "unstakeInitiated": "Unstake initiated",
+  "usdBalance": "USD Balance",
   "utilization": "Utilization",
   "vestingContract": "Vesting Contract",
   "virtualPrice": "Virtual price",

--- a/src/components/MyShareCard.tsx
+++ b/src/components/MyShareCard.tsx
@@ -54,43 +54,35 @@ function MyShareCard({ data }: Props): ReactElement | null {
       <Typography variant="h1" mb={3}>
         {t("myShare")}
       </Typography>
-      <div>
-        <div>
+      <Typography>
+        {formattedData.share} {t("ofPool")}
+      </Typography>
+      <Typography>{`${t("usdBalance")}: $${
+        formattedData.usdBalance
+      }`}</Typography>
+      <Typography>{`${t("totalAmount")}: ${formattedData.amount}`}</Typography>
+      {Object.keys(stakingUrls).map((key) => {
+        return data.amountsStaked[key as Partners]?.gt(Zero) ? (
           <Typography component="span">
-            {formattedData.share} {t("ofPool")}
+            &nbsp;
+            <a
+              href={stakingUrls[key]}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              ({formattedData.amountsStaked[key as Partners]} {t("staked")})
+            </a>
           </Typography>
-        </div>
-        <Box display="flex">
-          <Typography component="span">{`${t("usdBalance")}: `}</Typography>
-          <Typography component="span">{`$${formattedData.usdBalance}`}</Typography>
-        </Box>
-        <Box display="flex">
-          <Typography component="span">{`${t("totalAmount")}: `}</Typography>
-          <Typography component="span">{formattedData.amount}</Typography>
-        </Box>
-        {Object.keys(stakingUrls).map((key) => {
-          return data.amountsStaked[key as Partners]?.gt(Zero) ? (
-            <Typography component="span">
-              &nbsp;
-              <a
-                href={stakingUrls[key]}
-                target="_blank"
-                rel="noopener noreferrer"
-              >
-                ({formattedData.amountsStaked[key as Partners]} {t("staked")})
-              </a>
-            </Typography>
-          ) : null
-        })}
-      </div>
+        ) : null
+      })}
       <Stack direction="row" spacing={4} mb={3}>
         {formattedData.tokens.map((coin) => (
-          <div key={coin.symbol}>
+          <Box key={coin.symbol}>
             <Typography variant="subtitle1" data-testid="tokenName">
               {coin.symbol}
             </Typography>
             <Typography data-testid="tokenValue">{coin.value}</Typography>
-          </div>
+          </Box>
         ))}
       </Stack>
       <Divider />


### PR DESCRIPTION
Test was flakey. Removed wait() calls and non-essential loop logic. Now test will make a standard deposit, then assert toast renders with successful deposit message, then assert that one of the token values updates which indicates the deposit did indeed go through the flow successfully.

subtle UI format bug fix thrown in as well.