### PR TITLE
Break minichef and migrations out to their own fns

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1160,23 +1160,26 @@ export const POOLS_MAP: PoolsMap = {
 // @dev note that metapools refer to the deposit addresses and not the meta addresses
 const minichefPids: Partial<Record<ChainId, { [pool: string]: number }>> = {
   [ChainId.MAINNET]: {
-    [ALETH_SWAP_ADDRESSES[ChainId.MAINNET]]: 1,
-    [D4_SWAP_ADDRESSES[ChainId.MAINNET]]: 2,
-    [STABLECOIN_SWAP_V2_ADDRESSES[ChainId.MAINNET]]: 3,
-    [BTC_SWAP_V2_ADDRESSES[ChainId.MAINNET]]: 4,
-    [TBTC_META_SWAP_DEPOSIT_ADDRESSES[ChainId.MAINNET]]: 5,
-    [SUSD_META_SWAP_V2_DEPOSIT_ADDRESSES[ChainId.MAINNET]]: 6,
-    [WCUSD_META_SWAP_DEPOSIT_ADDRESSES[ChainId.MAINNET]]: 7,
+    [ALETH_SWAP_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 1,
+    [D4_SWAP_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 2,
+    [STABLECOIN_SWAP_V2_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 3,
+    [BTC_SWAP_V2_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 4,
+    [TBTC_META_SWAP_V2_DEPOSIT_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 5,
+    [TBTC_META_SWAP_V2_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 5,
+    [SUSD_META_SWAP_V2_DEPOSIT_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 6,
+    [SUSD_META_SWAP_V2_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 6,
+    [WCUSD_META_SWAP_V2_DEPOSIT_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 7,
+    [WCUSD_META_SWAP_V2_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 7,
   },
   [ChainId.HARDHAT]: {
-    [ALETH_SWAP_ADDRESSES[ChainId.HARDHAT]]: 1,
-    [D4_SWAP_ADDRESSES[ChainId.HARDHAT]]: 2,
-    [STABLECOIN_SWAP_V2_ADDRESSES[ChainId.HARDHAT]]: 3,
-    [BTC_SWAP_V2_ADDRESSES[ChainId.HARDHAT]]: 4,
+    [ALETH_SWAP_ADDRESSES[ChainId.HARDHAT].toLowerCase()]: 1,
+    [D4_SWAP_ADDRESSES[ChainId.HARDHAT].toLowerCase()]: 2,
+    [STABLECOIN_SWAP_V2_ADDRESSES[ChainId.HARDHAT].toLowerCase()]: 3,
+    [BTC_SWAP_V2_ADDRESSES[ChainId.HARDHAT].toLowerCase()]: 4,
   },
   [ChainId.ARBITRUM]: {
-    [ARB_USD_SWAP_ADDRESSES[ChainId.ARBITRUM]]: 1,
-    [USDS_ARB_USD_SWAP_ADDRESSES[ChainId.ARBITRUM]]: 2,
+    [ARB_USD_SWAP_ADDRESSES[ChainId.ARBITRUM].toLowerCase()]: 1,
+    [USDS_ARB_USD_SWAP_ADDRESSES[ChainId.ARBITRUM].toLowerCase()]: 2,
   },
 }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1156,6 +1156,48 @@ export const POOLS_MAP: PoolsMap = {
     rewardPids: buildPids({}),
   },
 }
+
+// @dev note that metapools refer to the deposit addresses and not the meta addresses
+const minichefPids: Partial<Record<ChainId, { [pool: string]: number }>> = {
+  [ChainId.MAINNET]: {
+    [ALETH_SWAP_ADDRESSES[ChainId.MAINNET]]: 1,
+    [D4_SWAP_ADDRESSES[ChainId.MAINNET]]: 2,
+    [STABLECOIN_SWAP_V2_ADDRESSES[ChainId.MAINNET]]: 3,
+    [BTC_SWAP_V2_ADDRESSES[ChainId.MAINNET]]: 4,
+    [TBTC_META_SWAP_DEPOSIT_ADDRESSES[ChainId.MAINNET]]: 5,
+    [SUSD_META_SWAP_V2_DEPOSIT_ADDRESSES[ChainId.MAINNET]]: 6,
+    [WCUSD_META_SWAP_DEPOSIT_ADDRESSES[ChainId.MAINNET]]: 7,
+  },
+  [ChainId.HARDHAT]: {
+    [ALETH_SWAP_ADDRESSES[ChainId.HARDHAT]]: 1,
+    [D4_SWAP_ADDRESSES[ChainId.HARDHAT]]: 2,
+    [STABLECOIN_SWAP_V2_ADDRESSES[ChainId.HARDHAT]]: 3,
+    [BTC_SWAP_V2_ADDRESSES[ChainId.HARDHAT]]: 4,
+  },
+  [ChainId.ARBITRUM]: {
+    [ARB_USD_SWAP_ADDRESSES[ChainId.ARBITRUM]]: 1,
+    [USDS_ARB_USD_SWAP_ADDRESSES[ChainId.ARBITRUM]]: 2,
+  },
+}
+
+export function getMinichefPid(
+  chainId: ChainId,
+  poolAddress: string,
+): number | null {
+  return minichefPids?.[chainId]?.[poolAddress] || null
+}
+
+export function getIsLegacySwapABIPoolByAddress(
+  chainId: ChainId,
+  poolAddress: string,
+): boolean {
+  const legacyAddresses = [
+    BTC_POOL_NAME,
+    STABLECOIN_POOL_NAME,
+    VETH2_POOL_NAME,
+  ].map((name) => POOLS_MAP[name].addresses[chainId])
+  return legacyAddresses.includes(poolAddress)
+}
 export function isLegacySwapABIPool(poolName: string): boolean {
   return new Set([BTC_POOL_NAME, STABLECOIN_POOL_NAME, VETH2_POOL_NAME]).has(
     poolName,
@@ -1297,22 +1339,22 @@ export const SUPPORTED_WALLETS: { [key: string]: WalletInfo } = {
 
 // derived from https://docs.synthetix.io/tokens/list/
 export const SYNTHETIX_TOKENS = [
-  "0xd2dF355C19471c8bd7D8A3aa27Ff4e26A21b4076", // Aave (sAAVE),
-  "0xF48e200EAF9906362BB1442fca31e0835773b8B4", // Australian Dollars (sAUD),
-  "0xfE18be6b3Bd88A2D2A7f928d00292E7a9963CfC6", // Bitcoin (sBTC),
-  "0xe36E2D3c7c34281FA3bC737950a68571736880A1", // Cardano (sADA),
-  "0xbBC455cb4F1B9e4bFC4B73970d360c8f032EfEE6", // Chainlink (sLINK),
-  "0xe1aFe1Fd76Fd88f78cBf599ea1846231B8bA3B6B", // DeFi Index (sDEFI),
-  "0x104eDF1da359506548BFc7c25bA1E28C16a70235", // ETH / BTC (sETHBTC),
-  "0x5e74C9036fb86BD7eCdcb084a0673EFc32eA31cb", // Ether (sETH),
-  "0xD71eCFF9342A5Ced620049e616c5035F1dB98620", // Euros (sEUR),
-  "0xF6b1C627e95BFc3c1b4c9B825a032Ff0fBf3e07d", // Japanese Yen (sJPY),
-  "0x1715AC0743102BF5Cd58EfBB6Cf2dC2685d967b6", // Polkadot (sDOT),
-  "0x97fe22E7341a0Cd8Db6F6C021A24Dc8f4DAD855F", // Pound Sterling (sGBP),
-  "0x269895a3dF4D73b077Fc823dD6dA1B95f72Aaf9B", // South Korean Won (sKRW),
-  "0x0F83287FF768D1c1e17a42F44d644D7F22e8ee1d", // Swiss Franc (sCHF),
-  "0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F", // Synthetix (SNX),
-  "0x57Ab1ec28D129707052df4dF418D58a2D46d5f51", // US Dollars (sUSD)
+  "0xd2df355c19471c8bd7d8a3aa27ff4e26a21b4076", // Aave (sAAVE)
+  "0xf48e200eaf9906362bb1442fca31e0835773b8b4", // Australian Dollars (sAUD)
+  "0xfe18be6b3bd88a2d2a7f928d00292e7a9963cfc6", // Bitcoin (sBTC)
+  "0xe36e2d3c7c34281fa3bc737950a68571736880a1", // Cardano (sADA)
+  "0xbbc455cb4f1b9e4bfc4b73970d360c8f032efee6", // Chainlink (sLINK)
+  "0xe1afe1fd76fd88f78cbf599ea1846231b8ba3b6b", // DeFi Index (sDEFI)
+  "0x104edf1da359506548bfc7c25ba1e28c16a70235", // ETH / BTC (sETHBTC)
+  "0x5e74c9036fb86bd7ecdcb084a0673efc32ea31cb", // Ether (sETH)
+  "0xd71ecff9342a5ced620049e616c5035f1db98620", // Euros (sEUR)
+  "0xf6b1c627e95bfc3c1b4c9b825a032ff0fbf3e07d", // Japanese Yen (sJPY)
+  "0x1715ac0743102bf5cd58efbb6cf2dc2685d967b6", // Polkadot (sDOT)
+  "0x97fe22e7341a0cd8db6f6c021a24dc8f4dad855f", // Pound Sterling (sGBP)
+  "0x269895a3df4d73b077fc823dd6da1b95f72aaf9b", // South Korean Won (sKRW)
+  "0x0f83287ff768d1c1e17a42f44d644d7f22e8ee1d", // Swiss Franc (sCHF)
+  "0xc011a73ee8576fb46f5e1c5751ca3b9fe0af2a6f", // Synthetix (SNX)
+  "0x57ab1ec28d129707052df4df418d58a2d46d5f51", // US Dollars (sUSD)
 ]
 
 // "SADDLE" in bytes32 form

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -2,12 +2,14 @@ import {
   ChainId,
   GENERALIZED_SWAP_MIGRATOR_CONTRACT_ADDRESSES,
 } from "../constants"
-import { MulticallContract, MulticallProvider } from "../types/ethcall"
 
 import { AddressZero } from "@ethersproject/constants"
 import { Contract } from "ethcall"
 import GENERALIZED_SWAP_MIGRATOR_CONTRACT_ABI from "../constants/abis/generalizedSwapMigrator.json"
 import { GeneralizedSwapMigrator } from "../../types/ethers-contracts/GeneralizedSwapMigrator"
+import { MulticallContract } from "../types/ethcall"
+import { Web3Provider } from "@ethersproject/providers"
+import { getMulticallProvider } from "."
 
 type MigrationData = { [poolAddress: string]: string } // current poolAddress => new poolAddress
 
@@ -15,10 +17,11 @@ type MigrationData = { [poolAddress: string]: string } // current poolAddress =>
  * Returns old -> new pool address mappings from GeneralizedMigrator for the given pool addresses.
  */
 export async function getMigrationData(
-  ethCallProvider: MulticallProvider,
+  library: Web3Provider,
   chainId: ChainId,
   poolAddresses: string[],
 ): Promise<MigrationData | null> {
+  const ethCallProvider = await getMulticallProvider(library, chainId)
   const migratorAddress = GENERALIZED_SWAP_MIGRATOR_CONTRACT_ADDRESSES[chainId]
   if (!ethCallProvider || !chainId || !migratorAddress) {
     return null

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -45,8 +45,8 @@ export async function getMigrationData(
     }, {} as MigrationData)
     return parsedData
   } catch (e) {
-    const error = new Error(`Failed to get migration data`)
-    error.stack = (e as Error).stack
+    const error = e as Error
+    error.message = `Failed to get migration data; ${error.message}`
     console.error(error)
     return null
   }

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -1,0 +1,53 @@
+import {
+  ChainId,
+  GENERALIZED_SWAP_MIGRATOR_CONTRACT_ADDRESSES,
+} from "../constants"
+import { MulticallContract, MulticallProvider } from "../types/ethcall"
+
+import { AddressZero } from "@ethersproject/constants"
+import { Contract } from "ethcall"
+import GENERALIZED_SWAP_MIGRATOR_CONTRACT_ABI from "../constants/abis/generalizedSwapMigrator.json"
+import { GeneralizedSwapMigrator } from "../../types/ethers-contracts/GeneralizedSwapMigrator"
+
+type MigrationData = { [poolAddress: string]: string } // current poolAddress => new poolAddress
+
+/**
+ * Returns old -> new pool address mappings from GeneralizedMigrator for the given pool addresses.
+ */
+export async function getMigrationData(
+  ethCallProvider: MulticallProvider,
+  chainId: ChainId,
+  poolAddresses: string[],
+): Promise<MigrationData | null> {
+  const migratorAddress = GENERALIZED_SWAP_MIGRATOR_CONTRACT_ADDRESSES[chainId]
+  if (!ethCallProvider || !chainId || !migratorAddress) {
+    return null
+  }
+  try {
+    const migratorContract = new Contract(
+      migratorAddress,
+      GENERALIZED_SWAP_MIGRATOR_CONTRACT_ABI,
+    ) as MulticallContract<GeneralizedSwapMigrator>
+
+    const calls = poolAddresses.map((address) =>
+      migratorContract.migrationMap(address),
+    )
+    const results = await ethCallProvider.tryEach(
+      calls,
+      Array(calls.length).fill(true),
+    )
+    const parsedData = poolAddresses.reduce((acc, address, i) => {
+      const result = results[i]?.newPoolAddress
+      if (result && result !== AddressZero) {
+        return { [address]: result, ...acc }
+      }
+      return acc
+    }, {} as MigrationData)
+    return parsedData
+  } catch (e) {
+    const error = new Error(`Failed to get migration data`)
+    error.stack = (e as Error).stack
+    console.error(error)
+    return null
+  }
+}

--- a/src/utils/minichef.ts
+++ b/src/utils/minichef.ts
@@ -59,8 +59,8 @@ export async function getMinichefRewardsData(
       return acc
     }, {} as MinichefData)
   } catch (e) {
-    const error = new Error(`Failed to get minichef data`)
-    error.stack = (e as Error).stack
+    const error = e as Error
+    error.message = `Failed to get minichef data; ${error.message}`
     console.error(error)
     return null
   }

--- a/src/utils/minichef.ts
+++ b/src/utils/minichef.ts
@@ -3,64 +3,219 @@ import {
   MINICHEF_CONTRACT_ADDRESSES,
   getMinichefPid,
 } from "../constants"
-import { MulticallContract, MulticallProvider } from "../types/ethcall"
 
+import { AddressZero } from "@ethersproject/constants"
 import { BigNumber } from "@ethersproject/bignumber"
-import { Contract } from "ethcall"
+import { Contract } from "@ethersproject/contracts"
+import { Contract as EthcallContract } from "ethcall"
+import { IRewarder } from "../../types/ethers-contracts/IRewarder"
+import IRewarder_ABI from "../constants/abis/IRewarder.json"
 import MINICHEF_CONTRACT_ABI from "../constants/abis/miniChef.json"
 import { MiniChef } from "../../types/ethers-contracts/MiniChef"
+import { MulticallContract } from "../types/ethcall"
+import { Web3Provider } from "@ethersproject/providers"
+import { getMulticallProvider } from "."
 
-type MinichefData = {
-  [poolAddress: string]: { sdlPerDay: BigNumber; pid: number }
+type MinichefPoolsData = {
+  [poolAddress: string]: {
+    sdlPerDay: BigNumber
+    pid: number
+    rewards?: RewardsData
+  }
 }
+type MinichefUserData = {
+  [pid: number]: {
+    amountStaked: BigNumber
+    rewardDebt: BigNumber
+  }
+} | null
+type RewardsData = {
+  rewarderAddress: string
+  rewardPerSecond: BigNumber
+  rewardPerDay: BigNumber
+  rewardTokenAddress: string
+}
+type MinichefRewardersData = {
+  [pid: number]: RewardsData
+}
+const oneDaySecs = BigNumber.from(24 * 60 * 60)
 
 /**
  * Returns sdlPerDay and pid from minichef for the given pool addresses.
  */
-export async function getMinichefRewardsData(
-  ethCallProvider: MulticallProvider,
+export async function getMinichefRewardsPoolsData(
+  library: Web3Provider,
   chainId: ChainId,
   poolAddresses: string[],
-): Promise<MinichefData | null> {
+): Promise<MinichefPoolsData | null> {
+  const ethCallProvider = await getMulticallProvider(library, chainId)
   const minichefAddress = MINICHEF_CONTRACT_ADDRESSES[chainId]
-  const addressesPidTuples = poolAddresses
-    .map((poolAddress) => [poolAddress, getMinichefPid(chainId, poolAddress)])
-    .filter(([, pid]) => !!pid) as [string, number][]
+  const addressesPidTuples = getPidsForPools(chainId, poolAddresses)
   if (!addressesPidTuples.length || !minichefAddress || !ethCallProvider)
     return null
   try {
-    const minichefContract = new Contract(
+    const minichefContract = new EthcallContract(
       minichefAddress,
       MINICHEF_CONTRACT_ABI,
     ) as MulticallContract<MiniChef>
 
+    // Fetch SDL distribution amounts
     const [saddlePerSecond, totalAllocPoint] = await ethCallProvider.tryEach(
       [minichefContract.saddlePerSecond(), minichefContract.totalAllocPoint()],
       [false, false],
     )
 
+    // Fetch SDL reward info for each pool
     const poolInfos = await ethCallProvider.tryEach(
       addressesPidTuples.map(([, pid]) => minichefContract.poolInfo(pid)),
       Array(addressesPidTuples.length).fill(true),
     )
-    const oneDaySecs = BigNumber.from(24 * 60 * 60)
-    return addressesPidTuples.reduce((acc, [address, pid], i) => {
+
+    // Fetch Rewarder Data
+    const rewardersData = await getMinichefRewardsRewardersData(
+      library,
+      chainId,
+      poolAddresses,
+    )
+
+    // Aggregate Data
+    const poolsData = addressesPidTuples.reduce((acc, [address, pid], i) => {
       const poolInfo = poolInfos[i]
+      const rewardsData = rewardersData?.[pid]
       if (poolInfo) {
         const sdlPerDay = saddlePerSecond
           .mul(oneDaySecs)
           .mul(poolInfo.allocPoint)
           .div(totalAllocPoint)
         return {
-          [address]: { sdlPerDay, pid },
+          [address]: { sdlPerDay, pid, ...({ rewards: rewardsData } || {}) },
           ...acc,
         }
       }
       return acc
-    }, {} as MinichefData)
+    }, {} as MinichefPoolsData)
+
+    return poolsData
   } catch (e) {
     const error = e as Error
-    error.message = `Failed to get minichef data; ${error.message}`
+    error.message = `Failed to get pools minichef data; ${error.message}`
+    console.error(error)
+    return null
+  }
+}
+
+function getPidsForPools(
+  chainId: ChainId,
+  poolAddresses: string[],
+): [string, number][] {
+  return poolAddresses
+    .map((poolAddress) => [poolAddress, getMinichefPid(chainId, poolAddress)])
+    .filter(([, pid]) => !!pid) as [string, number][]
+}
+
+export async function getMinichefRewardsRewardersData(
+  library: Web3Provider,
+  chainId: ChainId,
+  poolAddresses: string[],
+): Promise<MinichefRewardersData | null> {
+  const ethCallProvider = await getMulticallProvider(library, chainId)
+  const minichefAddress = MINICHEF_CONTRACT_ADDRESSES[chainId]
+  const addressesPidTuples = getPidsForPools(chainId, poolAddresses)
+  if (!addressesPidTuples.length || !minichefAddress || !ethCallProvider)
+    return null
+  try {
+    const minichefContract = new EthcallContract(
+      minichefAddress,
+      MINICHEF_CONTRACT_ABI,
+    ) as MulticallContract<MiniChef>
+    // Fetch Rewarder Data
+    const rewarderAddresses = await ethCallProvider.tryEach(
+      addressesPidTuples.map(([, pid]) => minichefContract.rewarder(pid)),
+      Array(addressesPidTuples.length).fill(true),
+    )
+    const rewarderContractsMap = {} as { [pid: number]: IRewarder }
+    rewarderAddresses.forEach((address, i) => {
+      if (address !== AddressZero) {
+        const pid = addressesPidTuples[i][1]
+        rewarderContractsMap[pid] = new Contract(
+          address,
+          IRewarder_ABI,
+          library,
+        ) as IRewarder
+      }
+    })
+    // const rewarderTokens = {} as { [pid: number]: string }
+    const rewarderPids = Object.keys(rewarderContractsMap)
+    const rewarderTokens = await Promise.all(
+      rewarderPids.map((pid) => rewarderContractsMap[pid].rewardToken()),
+    )
+    const rewarderAmountPerSeconds = await Promise.all(
+      rewarderPids.map((pid) => rewarderContractsMap[pid].rewardPerSecond()),
+    )
+    const poolsRewarderData = rewarderPids.reduce((acc, pid, i) => {
+      const rewarderContract = rewarderContractsMap[pid]
+      const rewardTokenAddress = rewarderTokens[i]
+      const rewardPerSecond = rewarderAmountPerSeconds[i]
+      const rewardPerDay = rewardPerSecond.mul(oneDaySecs)
+      return {
+        ...acc,
+        [pid]: {
+          rewardTokenAddress,
+          rewardPerDay,
+          rewardPerSecond,
+          rewarderAddress: rewarderContract.address,
+        },
+      }
+    }, {} as MinichefRewardersData)
+    return poolsRewarderData
+  } catch (e) {
+    const error = e as Error
+    error.message = `Failed to get minichef rewarders data; ${error.message}`
+    console.error(error)
+    return null
+  }
+}
+
+export async function getMinichefRewardsUserData(
+  library: Web3Provider,
+  chainId: ChainId,
+  poolAddresses: string[],
+  account?: string,
+): Promise<MinichefUserData | null> {
+  const ethCallProvider = await getMulticallProvider(library, chainId)
+  const minichefAddress = MINICHEF_CONTRACT_ADDRESSES[chainId]
+  const addressesPidTuples = getPidsForPools(chainId, poolAddresses)
+  if (
+    !addressesPidTuples.length ||
+    !minichefAddress ||
+    !ethCallProvider ||
+    !account
+  )
+    return null
+  try {
+    const minichefContract = new EthcallContract(
+      minichefAddress,
+      MINICHEF_CONTRACT_ABI,
+    ) as MulticallContract<MiniChef>
+    const userPoolsInfo = await ethCallProvider.tryEach(
+      addressesPidTuples.map(([, pid]) =>
+        minichefContract.userInfo(pid, account),
+      ),
+      Array(addressesPidTuples.length).fill(true),
+    )
+    return userPoolsInfo.reduce((acc, poolInfo, i) => {
+      const [, pid] = addressesPidTuples[i]
+      return {
+        ...acc,
+        [pid]: {
+          amountStaked: poolInfo.amount,
+          rewardDebt: poolInfo.rewardDebt,
+        },
+      }
+    }, {} as MinichefUserData)
+  } catch (e) {
+    const error = e as Error
+    error.message = `Failed to get user minichef data; ${error.message}`
     console.error(error)
     return null
   }

--- a/src/utils/minichef.ts
+++ b/src/utils/minichef.ts
@@ -1,0 +1,67 @@
+import {
+  ChainId,
+  MINICHEF_CONTRACT_ADDRESSES,
+  getMinichefPid,
+} from "../constants"
+import { MulticallContract, MulticallProvider } from "../types/ethcall"
+
+import { BigNumber } from "@ethersproject/bignumber"
+import { Contract } from "ethcall"
+import MINICHEF_CONTRACT_ABI from "../constants/abis/miniChef.json"
+import { MiniChef } from "../../types/ethers-contracts/MiniChef"
+
+type MinichefData = {
+  [poolAddress: string]: { sdlPerDay: BigNumber; pid: number }
+}
+
+/**
+ * Returns sdlPerDay and pid from minichef for the given pool addresses.
+ */
+export async function getMinichefRewardsData(
+  ethCallProvider: MulticallProvider,
+  chainId: ChainId,
+  poolAddresses: string[],
+): Promise<MinichefData | null> {
+  const minichefAddress = MINICHEF_CONTRACT_ADDRESSES[chainId]
+  const addressesPidTuples = poolAddresses
+    .map((poolAddress) => [poolAddress, getMinichefPid(chainId, poolAddress)])
+    .filter(([, pid]) => !!pid) as [string, number][]
+  if (!addressesPidTuples.length || !minichefAddress || !ethCallProvider)
+    return null
+  try {
+    const minichefContract = new Contract(
+      minichefAddress,
+      MINICHEF_CONTRACT_ABI,
+    ) as MulticallContract<MiniChef>
+
+    const [saddlePerSecond, totalAllocPoint] = await ethCallProvider.tryEach(
+      [minichefContract.saddlePerSecond(), minichefContract.totalAllocPoint()],
+      [false, false],
+    )
+
+    const poolInfos = await ethCallProvider.tryEach(
+      addressesPidTuples.map(([, pid]) => minichefContract.poolInfo(pid)),
+      Array(addressesPidTuples.length).fill(true),
+    )
+    const oneDaySecs = BigNumber.from(24 * 60 * 60)
+    return addressesPidTuples.reduce((acc, [address, pid], i) => {
+      const poolInfo = poolInfos[i]
+      if (poolInfo) {
+        const sdlPerDay = saddlePerSecond
+          .mul(oneDaySecs)
+          .mul(poolInfo.allocPoint)
+          .div(totalAllocPoint)
+        return {
+          [address]: { sdlPerDay, pid },
+          ...acc,
+        }
+      }
+      return acc
+    }, {} as MinichefData)
+  } catch (e) {
+    const error = new Error(`Failed to get minichef data`)
+    error.stack = (e as Error).stack
+    console.error(error)
+    return null
+  }
+}


### PR DESCRIPTION
The first of several steps to remove logic from usePoolData and separate concerns into their own files. Notice I'm also moving from poolname to address