### PR TITLE
Hide Zero SDL per day from PoolOverview

### DIFF
--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -173,7 +173,7 @@ export default function PoolOverview({
           )}
         </StyledGrid>
         <StyledGrid item xs={6} lg={2.5} disabled={disableText}>
-          {poolData.sdlPerDay != null && IS_SDL_LIVE && (
+          {poolData.sdlPerDay?.gt(Zero) && IS_SDL_LIVE && (
             <Box sx={{ display: "flex", alignItems: "center" }}>
               <Typography variant="subtitle1" mr={1}>
                 <Link


### PR DESCRIPTION
Before:
<img width="981" alt="Screen Shot 2022-04-28 at 8 27 51 AM" src="https://user-images.githubusercontent.com/7607886/165788433-46d18de3-4e7a-4298-9133-638dec13414c.png">

After
<img width="981" alt="Screen Shot 2022-04-28 at 8 27 31 AM" src="https://user-images.githubusercontent.com/7607886/165788534-ebea4633-6a46-485d-b3ae-1ab135b1eb03.png">

