### PR TITLE
Add pool contract address information on PoolInfoCard

### DIFF
--- a/src/components/PoolInfoCard.tsx
+++ b/src/components/PoolInfoCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Typography, styled } from "@mui/material"
+import { Box, Divider, Link, Typography, styled } from "@mui/material"
 import { POOLS_MAP, POOL_FEE_PRECISION, PoolTypes } from "../constants"
 import React, { ReactElement } from "react"
 import {
@@ -14,6 +14,7 @@ import { PoolDataType } from "../hooks/usePoolData"
 import TokenIcon from "./TokenIcon"
 import { Tooltip } from "@mui/material"
 import { Zero } from "@ethersproject/constants"
+import { shortenAddress } from "../utils/shortenAddress"
 import { useActiveWeb3React } from "../hooks"
 import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
@@ -40,6 +41,8 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
     POOLS_MAP?.[data.name]?.metaSwapAddresses?.[chainId] ||
     POOLS_MAP?.[data.name]?.addresses[chainId]
   )?.toLowerCase()
+  console.log("pool addr =>", poolAddress)
+  console.log("pool addr =>", data.lpToken)
   const { oneDayVolume, utilization } =
     swapStats && poolAddress in swapStats
       ? swapStats[poolAddress]
@@ -105,7 +108,9 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
           </Typography>
         </Tooltip>
       ) : (
-        <Typography variant="h1">{formattedData.name}</Typography>
+        <Typography component="span" variant="h1" mr={2}>
+          {formattedData.name}
+        </Typography>
       )}
       <InfoItem mt={3}>
         <Typography>{`${t("status")}:`}</Typography>
@@ -204,6 +209,27 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
             </Box>
           ))}
         </Box>
+        <Typography mt={3}>
+          Pool address:&nbsp;
+          <Link
+            href={`https://etherscan.io/address/${poolAddress}`}
+            target="_blank"
+            color="inherit"
+          >
+            {shortenAddress(poolAddress)}
+          </Link>
+        </Typography>
+        <Typography mt={1}>
+          LP token address:&nbsp;
+          <Link
+            href={`https://etherscan.io/address/${data.lpToken}`}
+            target="_blank"
+            color="inherit"
+          >
+            {data.lpToken && shortenAddress(data.lpToken)}
+          </Link>
+        </Typography>
+        {/* TODO: Gauge link */}
       </Box>
     </Box>
   )

--- a/src/components/PoolInfoCard.tsx
+++ b/src/components/PoolInfoCard.tsx
@@ -209,21 +209,23 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
           ))}
         </Box>
         <Typography mt={3}>
-          Pool address:&nbsp;
+          Pool address:
           <Link
             href={getMultichainScanLink(chainId, poolAddress, "address")}
             target="_blank"
             color="inherit"
+            ml={1}
           >
             {shortenAddress(poolAddress)}
           </Link>
         </Typography>
         <Typography mt={1}>
-          LP token address:&nbsp;
+          LP token address:
           <Link
             href={getMultichainScanLink(chainId, data.lpToken, "token")}
             target="_blank"
             color="inherit"
+            ml={1}
           >
             {data.lpToken && shortenAddress(data.lpToken)}
           </Link>

--- a/src/components/PoolInfoCard.tsx
+++ b/src/components/PoolInfoCard.tsx
@@ -14,6 +14,7 @@ import { PoolDataType } from "../hooks/usePoolData"
 import TokenIcon from "./TokenIcon"
 import { Tooltip } from "@mui/material"
 import { Zero } from "@ethersproject/constants"
+import { getMultichainScanLink } from "../utils/getEtherscanLink"
 import { shortenAddress } from "../utils/shortenAddress"
 import { useActiveWeb3React } from "../hooks"
 import { useSelector } from "react-redux"
@@ -41,8 +42,6 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
     POOLS_MAP?.[data.name]?.metaSwapAddresses?.[chainId] ||
     POOLS_MAP?.[data.name]?.addresses[chainId]
   )?.toLowerCase()
-  console.log("pool addr =>", poolAddress)
-  console.log("pool addr =>", data.lpToken)
   const { oneDayVolume, utilization } =
     swapStats && poolAddress in swapStats
       ? swapStats[poolAddress]
@@ -212,7 +211,7 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
         <Typography mt={3}>
           Pool address:&nbsp;
           <Link
-            href={`https://etherscan.io/address/${poolAddress}`}
+            href={getMultichainScanLink(chainId, poolAddress, "address")}
             target="_blank"
             color="inherit"
           >
@@ -222,7 +221,7 @@ function PoolInfoCard({ data }: Props): ReactElement | null {
         <Typography mt={1}>
           LP token address:&nbsp;
           <Link
-            href={`https://etherscan.io/address/${data.lpToken}`}
+            href={getMultichainScanLink(chainId, data.lpToken, "token")}
             target="_blank"
             color="inherit"
           >

--- a/src/components/Toastify.tsx
+++ b/src/components/Toastify.tsx
@@ -109,9 +109,7 @@ export const enqueuePromiseToast = (
               href={getMultichainScanLink(
                 chainId,
                 data?.transactionHash ?? "",
-                chainId === ChainId.EVMOS || chainId === ChainId.EVMOS_TESTNET
-                  ? "txs"
-                  : "tx",
+                "tx",
               )}
               target="_blank"
               rel="noreferrer"

--- a/src/utils/getEtherscanLink.ts
+++ b/src/utils/getEtherscanLink.ts
@@ -26,7 +26,7 @@ export function getMultichainScanLink(
       chainScanDomain = "explorer.evm-alpha.kava.io"
       break
     default:
-      chainScanDomain = "etherscan"
+      chainScanDomain = "etherscan.io"
   }
 
   return `https://${chainScanDomain}/${type}/${data}`

--- a/src/utils/getEtherscanLink.ts
+++ b/src/utils/getEtherscanLink.ts
@@ -5,31 +5,31 @@ export function getMultichainScanLink(
   data: string,
   type: "tx" | "token" | "address" | "block" | "txs",
 ): string {
-  let chainScanBaseName = "etherscan.io"
+  let chainScanDomain = "etherscan.io"
   switch (chainId) {
     case ChainId.MAINNET:
-      chainScanBaseName = "etherscan.io"
+      chainScanDomain = "etherscan.io"
       break
     case ChainId.ARBITRUM:
-      chainScanBaseName = "arbiscan.io"
+      chainScanDomain = "arbiscan.io"
       break
     case ChainId.FANTOM:
-      chainScanBaseName = "ftmscan.com"
+      chainScanDomain = "ftmscan.com"
       break
     case ChainId.OPTIMISM:
-      chainScanBaseName = "optimistic.etherscan.io"
+      chainScanDomain = "optimistic.etherscan.io"
       break
     case ChainId.EVMOS || ChainId.EVMOS_TESTNET:
-      chainScanBaseName = "mintscan.io"
+      chainScanDomain = "evm.evmos.org"
       break
     case ChainId.KAVA_TESTNET:
-      chainScanBaseName = "explorer.evm-alpha.kava.io"
+      chainScanDomain = "explorer.evm-alpha.kava.io"
       break
     default:
-      chainScanBaseName = "etherscan"
+      chainScanDomain = "etherscan"
   }
 
-  return `https://${chainScanBaseName}/${type}/${data}`
+  return `https://${chainScanDomain}/${type}/${data}`
 }
 
 export function getEtherscanLink(

--- a/src/utils/getEtherscanLink.ts
+++ b/src/utils/getEtherscanLink.ts
@@ -5,31 +5,31 @@ export function getMultichainScanLink(
   data: string,
   type: "tx" | "token" | "address" | "block" | "txs",
 ): string {
-  let chainScanBaseName = "etherscan"
+  let chainScanBaseName = "etherscan.io"
   switch (chainId) {
     case ChainId.MAINNET:
-      chainScanBaseName = "etherscan"
+      chainScanBaseName = "etherscan.io"
       break
     case ChainId.ARBITRUM:
-      chainScanBaseName = "arbiscan"
+      chainScanBaseName = "arbiscan.io"
       break
     case ChainId.FANTOM:
-      chainScanBaseName = "ftmscan"
+      chainScanBaseName = "ftmscan.com"
       break
     case ChainId.OPTIMISM:
-      chainScanBaseName = "optimistic.etherscan"
+      chainScanBaseName = "optimistic.etherscan.io"
       break
     case ChainId.EVMOS || ChainId.EVMOS_TESTNET:
-      chainScanBaseName = "mintscan"
+      chainScanBaseName = "mintscan.io"
       break
     case ChainId.KAVA_TESTNET:
-      chainScanBaseName = "evm-alpha.kava"
+      chainScanBaseName = "explorer.evm-alpha.kava.io"
       break
     default:
       chainScanBaseName = "etherscan"
   }
 
-  return `https://${chainScanBaseName}.io/${type}/${data}`
+  return `https://${chainScanBaseName}/${type}/${data}`
 }
 
 export function getEtherscanLink(


### PR DESCRIPTION
## Description
 It's quite difficult to find the `token contracts` associated with a `pool`, especially the `LP token`.
This PR adds the token contract and LP token conract address on `PoolInfoCard` component.

## Context

https://www.figma.com/file/Aa3IfDUO68aCNr8nZTuQ8S/Product-Design-with-MUI?node-id=762%3A32576
https://saddle-finance.slack.com/archives/C019X395350/p1650985929086549

## 
closes: https://github.com/saddle-finance/saddle-frontend/issues/811