### PR TITLE
Add dark mode on highchart and center Circular progress

### DIFF
--- a/src/components/GaugeWeight.tsx
+++ b/src/components/GaugeWeight.tsx
@@ -92,14 +92,12 @@ export default function GaugeWeight({
   }
 
   return (
-    <div>
-      <PieChart
-        highcharts={Highcharts}
-        options={options}
-        ref={chartComponentRef}
-        allowChartUpdate
-        {...props}
-      />
-    </div>
+    <PieChart
+      highcharts={Highcharts}
+      options={options}
+      ref={chartComponentRef}
+      allowChartUpdate
+      {...props}
+    />
   )
 }

--- a/src/components/GaugeWeight.tsx
+++ b/src/components/GaugeWeight.tsx
@@ -1,7 +1,7 @@
 import { BasicPool, BasicPoolsContext } from "../providers/BasicPoolsProvider"
+import { CircularProgress, useTheme } from "@mui/material"
 import React, { useContext, useRef } from "react"
 import { BigNumber } from "@ethersproject/bignumber"
-import { CircularProgress } from "@mui/material"
 import Highcharts from "highcharts"
 import HighchartsExporting from "highcharts/modules/exporting"
 import HighchartsReact from "highcharts-react-official"
@@ -25,6 +25,7 @@ export default function GaugeWeight({
   HighchartsExporting(Highcharts)
   const chartComponentRef = useRef<HighchartsReact.RefObject>(null)
   const pools = useContext(BasicPoolsContext)
+  const theme = useTheme()
   if (pools == undefined) return <CircularProgress color="secondary" />
 
   const gaugesInfo = (Object.values(pools) as BasicPool[])
@@ -49,8 +50,14 @@ export default function GaugeWeight({
   })
 
   const options: Highcharts.Options = {
+    chart: {
+      backgroundColor: theme.palette.background.paper,
+    },
     title: {
       text: "Gauge Relative Weight",
+      style: {
+        color: theme.palette.text.primary,
+      },
     },
     exporting: {
       enabled: true,
@@ -85,12 +92,14 @@ export default function GaugeWeight({
   }
 
   return (
-    <PieChart
-      highcharts={Highcharts}
-      options={options}
-      ref={chartComponentRef}
-      allowChartUpdate
-      {...props}
-    />
+    <div>
+      <PieChart
+        highcharts={Highcharts}
+        options={options}
+        ref={chartComponentRef}
+        allowChartUpdate
+        {...props}
+      />
+    </div>
   )
 }

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -475,7 +475,7 @@ export const HELPER_CONTRACT_ADDRESSES = buildAddresses({
 })
 
 export const GAUGE_CONTROLLER_ADDRESSES = buildAddresses({
-  [ChainId.HARDHAT]: "0x07882Ae1ecB7429a84f1D53048d35c4bB2056877",
+  [ChainId.HARDHAT]: "0xc0F115A19107322cFBf1cDBC7ea011C19EbDB4F8",
 })
 
 export const SPA = new Token(

--- a/src/pages/VeSDL/GaugeVote.tsx
+++ b/src/pages/VeSDL/GaugeVote.tsx
@@ -25,9 +25,16 @@ export default function GaugeVote(): JSX.Element {
       <Typography variant="h2" textAlign="center">
         {t("gaugeVote")}
       </Typography>
-      <Box>
+      <Box height="428px">
         {!gaugeData ? (
-          <CircularProgress color="secondary" />
+          <Box
+            display="flex"
+            height="100%"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <CircularProgress color="secondary" />
+          </Box>
         ) : (
           <GaugeWeight gauges={gaugeData.gauges} />
         )}

--- a/src/pages/VeSDL/GaugeVote.tsx
+++ b/src/pages/VeSDL/GaugeVote.tsx
@@ -25,7 +25,7 @@ export default function GaugeVote(): JSX.Element {
       <Typography variant="h2" textAlign="center">
         {t("gaugeVote")}
       </Typography>
-      <Box height="428px">
+      <Box minHeight="428px">
         {!gaugeData ? (
           <Box
             display="flex"


### PR DESCRIPTION
## Description.
- Add dark background color on highchart
- Center circluar loading for GaugeVote.

## Context

https://github.com/saddle-finance/saddle-frontend/issues/1004

close: https://github.com/saddle-finance/saddle-frontend/issues/1004

## Screenshot
![Screen Shot 2022-05-11 at 1 15 22 AM](https://user-images.githubusercontent.com/75422800/167730565-a4d5caae-04ac-4f05-9010-81fa707e1f50.png)
![Screen Shot 2022-05-11 at 1 15 30 AM](https://user-images.githubusercontent.com/75422800/167730579-c154e144-e376-4d04-864b-29e6c4bb1ed6.png)
![image](https://user-images.githubusercontent.com/75422800/167730662-50ab71e1-8350-42da-a9c0-872b29be1807.png)

![image](https://user-images.githubusercontent.com/75422800/167916297-045c29af-a31b-410a-b50e-3165d97fdca0.png)
