### PR TITLE
Remove POOLS_MAP from withdraw flow, replaces symbols with addresses

### DIFF
--- a/cypress/integration/withdrawal.test.ts
+++ b/cypress/integration/withdrawal.test.ts
@@ -1,9 +1,9 @@
 import { PoolName } from "../../src/constants"
 
 // have two seperate maps here since the naming convention is different throughout the page
-const poolTokensFullName: { [key: string]: string[] } = {
+const poolTokensSymbols: { [key: string]: string[] } = {
   "BTC V2": ["WBTC", "renBTC", "sBTC"],
-  "Stablecoin V2": ["Dai", "USDC Coin", "Tether"],
+  "Stablecoin V2": ["DAI", "USDC", "USDT"],
 }
 const pools = ["BTC V2", "Stablecoin V2"]
 
@@ -46,7 +46,7 @@ context("Withdrawal Flow", () => {
           cy.get("button").contains("Withdraw").click()
         })
       // test single item
-      const tokens = poolTokensFullName[poolName]
+      const tokens = poolTokensSymbols[poolName]
       cy.get('[data-testid="withdrawTokenRadio"]')
         .contains(tokens[0], { matchCase: false })
         .click()

--- a/cypress/integration/withdrawal.test.ts
+++ b/cypress/integration/withdrawal.test.ts
@@ -47,7 +47,9 @@ context("Withdrawal Flow", () => {
         })
       // test single item
       const tokens = poolTokensFullName[poolName]
-      cy.get('[data-testid="withdrawTokenRadio"]').contains(tokens[0]).click()
+      cy.get('[data-testid="withdrawTokenRadio"]')
+        .contains(tokens[0], { matchCase: false })
+        .click()
       cy.get('[data-testid="myFarmLpBalance"]').should("not.have.text", "0.0")
       cy.wait(10000)
       cy.get("#tokenInput input").first().type("1")

--- a/src/components/WithdrawPage.tsx
+++ b/src/components/WithdrawPage.tsx
@@ -165,7 +165,7 @@ const WithdrawPage = (props: Props): ReactElement | null => {
                       control={<Radio />}
                       value={t.address}
                       // disabled={poolData?.isPaused}
-                      label={t.name}
+                      label={t.symbol}
                       data-testid="withdrawTokenRadio"
                     />
                   )

--- a/src/components/WithdrawPage.tsx
+++ b/src/components/WithdrawPage.tsx
@@ -59,6 +59,7 @@ interface Props {
   title: string
   tokensData: Array<{
     symbol: string
+    address: string
     name: string
     inputValue: string
   }>
@@ -72,7 +73,7 @@ interface Props {
 }
 /* eslint-enable @typescript-eslint/no-explicit-any */
 
-const WithdrawPage = (props: Props): ReactElement => {
+const WithdrawPage = (props: Props): ReactElement | null => {
   const { t } = useTranslation()
   const {
     tokensData,
@@ -100,7 +101,7 @@ const WithdrawPage = (props: Props): ReactElement => {
   }
   const noShare = !myShareData || myShareData.lpTokenBalance.eq(Zero)
 
-  return (
+  return !poolData ? null : (
     <Container maxWidth={isLgDown ? "sm" : "lg"} sx={{ py: 5 }}>
       <Stack
         direction={{ xs: "column", lg: "row" }}
@@ -158,7 +159,7 @@ const WithdrawPage = (props: Props): ReactElement => {
                 {tokensData.map((t) => {
                   return (
                     <FormControlLabel
-                      key={t.symbol}
+                      key={t.address}
                       control={<Radio />}
                       value={t.symbol}
                       // disabled={poolData?.isPaused}
@@ -178,6 +179,7 @@ const WithdrawPage = (props: Props): ReactElement => {
                         fieldName: "tokenInputs",
                         value: value,
                         tokenSymbol: token.symbol,
+                        address: token.address,
                       })
                     }
                     // disabled={poolData?.isPaused}

--- a/src/components/WithdrawPage.tsx
+++ b/src/components/WithdrawPage.tsx
@@ -163,7 +163,7 @@ const WithdrawPage = (props: Props): ReactElement | null => {
                     <FormControlLabel
                       key={t.address}
                       control={<Radio />}
-                      value={t.symbol}
+                      value={t.address}
                       // disabled={poolData?.isPaused}
                       label={t.name}
                       data-testid="withdrawTokenRadio"
@@ -173,7 +173,10 @@ const WithdrawPage = (props: Props): ReactElement | null => {
               </RadioGroup>
               <Stack spacing={3}>
                 {tokensData.map(
-                  ({ decimals, symbol, name, priceUSD, inputValue }, index) => (
+                  (
+                    { decimals, symbol, name, priceUSD, inputValue, address },
+                    index,
+                  ) => (
                     <TokenInput
                       key={index}
                       token={{
@@ -187,7 +190,7 @@ const WithdrawPage = (props: Props): ReactElement | null => {
                         onFormChange({
                           fieldName: "tokenInputs",
                           value: value,
-                          tokenSymbol: symbol,
+                          address,
                         })
                       }
                     />

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -957,7 +957,7 @@ const SBTC_CONTRACT_ADDRESSES = buildAddresses({
 export const SBTC = new Token(
   SBTC_CONTRACT_ADDRESSES,
   18,
-  "SBTC",
+  "sBTC",
   "sbtc",
   "sBTC",
   true,

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -957,7 +957,7 @@ const SBTC_CONTRACT_ADDRESSES = buildAddresses({
 export const SBTC = new Token(
   SBTC_CONTRACT_ADDRESSES,
   18,
-  "sBTC",
+  "SBTC", // TODO the mainnet symbol is sBTC but hardhat is SBTC
   "sbtc",
   "sBTC",
   true,

--- a/src/hooks/useApproveAndWithdraw.ts
+++ b/src/hooks/useApproveAndWithdraw.ts
@@ -48,10 +48,10 @@ export function useApproveAndWithdraw(
   ): Promise<void> {
     try {
       const basicPool = basicPools?.[poolName]
-      if (!state || !library || !lpTokenContract) return
+      if (!state) return
       if (!account || !chainId || !library)
         throw new Error("Wallet must be connected")
-      if (!swapContract || !basicPool)
+      if (!swapContract || !basicPool || !lpTokenContract)
         throw new Error("Swap contract is not loaded")
       if (state.lpTokenAmountToSpend.isZero()) return
 

--- a/src/hooks/useApproveAndWithdraw.ts
+++ b/src/hooks/useApproveAndWithdraw.ts
@@ -130,7 +130,7 @@ export function useApproveAndWithdraw(
           state.lpTokenAmountToSpend,
           basicPool.tokens.findIndex(
             (address) => address === state.withdrawType,
-          ), // TODO what
+          ), // @dev withdrawType is either token address or "reset"
           subtractSlippage(
             BigNumber.from(
               state.tokenFormState?.[state.withdrawType || ""]?.valueSafe ||

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -235,7 +235,7 @@ export function useSwapContract(
   return useMemo(() => {
     if (!pool || !library) return null
     try {
-      const poolAddress = pool.poolAddress
+      const poolAddress = pool.metaSwapDepositAddress || pool.poolAddress
       if (!poolAddress) return null
       return getSwapContract(library, poolAddress, pool, account ?? undefined)
     } catch (error) {

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -5,19 +5,18 @@ import {
   GENERALIZED_SWAP_MIGRATOR_CONTRACT_ADDRESSES,
   MASTER_REGISTRY_CONTRACT_ADDRESSES,
   MINICHEF_CONTRACT_ADDRESSES,
-  POOLS_MAP,
-  PoolName,
   RETROACTIVE_VESTING_CONTRACT_ADDRESSES,
   SYNTHETIX_CONTRACT_ADDRESSES,
   SYNTHETIX_EXCHANGE_RATES_CONTRACT_ADDRESSES,
   TOKENS_MAP,
   Token,
-  isLegacySwapABIPool,
-  isMetaPool,
 } from "../constants"
-import { useEffect, useMemo, useState } from "react"
+import { getContract, getSwapContract } from "../utils"
+import { useContext, useEffect, useMemo, useState } from "react"
+
 import { AddressZero } from "@ethersproject/constants"
 import BRIDGE_CONTRACT_ABI from "../constants/abis/bridge.json"
+import { BasicPoolsContext } from "../providers/BasicPoolsProvider"
 import { Bridge } from "../../types/ethers-contracts/Bridge"
 import { Contract } from "@ethersproject/contracts"
 import ERC20_ABI from "../constants/abis/erc20.json"
@@ -31,7 +30,6 @@ import LPTOKEN_UNGUARDED_ABI from "../constants/abis/lpTokenUnguarded.json"
 import { LpTokenGuarded } from "../../types/ethers-contracts/LpTokenGuarded"
 import { LpTokenUnguarded } from "../../types/ethers-contracts/LpTokenUnguarded"
 import MASTER_REGISTRY_ABI from "../constants/abis/masterRegistry.json"
-import META_SWAP_DEPOSIT_ABI from "../constants/abis/metaSwapDeposit.json"
 import MINICHEF_CONTRACT_ABI from "../constants/abis/miniChef.json"
 import { MasterRegistry } from "../../types/ethers-contracts/MasterRegistry"
 import { MetaSwapDeposit } from "../../types/ethers-contracts/MetaSwapDeposit"
@@ -42,9 +40,6 @@ import { PermissionlessDeployer } from "../../types/ethers-contracts/Permissionl
 import { PoolRegistry } from "../../types/ethers-contracts/PoolRegistry"
 import RETROACTIVE_VESTING_CONTRACT_ABI from "../constants/abis/retroactiveVesting.json"
 import { RetroactiveVesting } from "../../types/ethers-contracts/RetroactiveVesting"
-import SWAP_FLASH_LOAN_ABI from "../constants/abis/swapFlashLoan.json"
-import SWAP_FLASH_LOAN_NO_WITHDRAW_FEE_ABI from "../constants/abis/swapFlashLoanNoWithdrawFee.json"
-import SWAP_GUARDED_ABI from "../constants/abis/swapGuarded.json"
 import SYNTHETIX_EXCHANGE_RATE_CONTRACT_ABI from "../constants/abis/synthetixExchangeRate.json"
 import SYNTHETIX_NETWORK_TOKEN_CONTRACT_ABI from "../constants/abis/synthetixNetworkToken.json"
 import { SwapFlashLoan } from "../../types/ethers-contracts/SwapFlashLoan"
@@ -53,7 +48,6 @@ import { SwapGuarded } from "../../types/ethers-contracts/SwapGuarded"
 import { SynthetixExchangeRate } from "../../types/ethers-contracts/SynthetixExchangeRate"
 import { SynthetixNetworkToken } from "../../types/ethers-contracts/SynthetixNetworkToken"
 import { formatBytes32String } from "@ethersproject/strings"
-import { getContract } from "../utils"
 import { useActiveWeb3React } from "./index"
 
 // returns null on errors
@@ -227,87 +221,54 @@ export function useTokenContract(
   return useContract(tokenAddress, ERC20_ABI, withSignerIfPossible)
 }
 
-export function useSwapContract<T extends PoolName | string>(
+export function useSwapContract<T extends string>(
   poolName?: T,
 ): T extends typeof BTC_POOL_NAME
   ? SwapGuarded | null
   : SwapFlashLoan | SwapFlashLoanNoWithdrawFee | MetaSwapDeposit | null
 export function useSwapContract(
   poolName?: string,
-):
-  | SwapGuarded
-  | SwapFlashLoan
-  | SwapFlashLoanNoWithdrawFee
-  | MetaSwapDeposit
-  | null {
-  const { chainId, account, library } = useActiveWeb3React()
+): ReturnType<typeof getSwapContract> {
+  const { account, library } = useActiveWeb3React()
+  const basicPools = useContext(BasicPoolsContext)
+  const pool = poolName ? basicPools?.[poolName] : null
   return useMemo(() => {
-    if (!poolName || !library || !chainId) return null
+    if (!pool || !library) return null
     try {
-      const pool = POOLS_MAP[poolName]
-      const poolAddress = pool.addresses[chainId]
+      const poolAddress = pool.poolAddress
       if (!poolAddress) return null
-      if (poolName === BTC_POOL_NAME) {
-        return getContract(
-          poolAddress,
-          SWAP_GUARDED_ABI,
-          library,
-          account ?? undefined,
-        ) as SwapGuarded
-      } else if (isLegacySwapABIPool(poolName)) {
-        return getContract(
-          poolAddress,
-          SWAP_FLASH_LOAN_ABI,
-          library,
-          account ?? undefined,
-        ) as SwapFlashLoan
-      } else if (isMetaPool(poolName)) {
-        return getContract(
-          poolAddress,
-          META_SWAP_DEPOSIT_ABI,
-          library,
-          account ?? undefined,
-        ) as MetaSwapDeposit
-      } else if (pool) {
-        return getContract(
-          poolAddress,
-          SWAP_FLASH_LOAN_NO_WITHDRAW_FEE_ABI,
-          library,
-          account ?? undefined,
-        ) as SwapFlashLoanNoWithdrawFee
-      } else {
-        return null
-      }
+      return getSwapContract(library, poolAddress, pool, account ?? undefined)
     } catch (error) {
       console.error("Failed to get contract", error)
       return null
     }
-  }, [chainId, library, account, poolName])
+  }, [library, account, pool])
 }
 
-export function useLPTokenContract<T extends PoolName>(
+export function useLPTokenContract<T extends string>(
   poolName: T,
 ): T extends typeof BTC_POOL_NAME
   ? LpTokenGuarded | null
   : LpTokenUnguarded | null
 export function useLPTokenContract(
-  poolName: PoolName,
+  poolName: string,
 ): LpTokenUnguarded | LpTokenGuarded | null {
-  const { chainId, account, library } = useActiveWeb3React()
+  const { account, library } = useActiveWeb3React()
+  const basicPools = useContext(BasicPoolsContext)
+  const pool = basicPools?.[poolName]
   return useMemo(() => {
-    if (!poolName || !library || !chainId) return null
+    if (!library || !pool) return null
     try {
-      const pool = POOLS_MAP[poolName]
-      if (poolName == BTC_POOL_NAME) {
+      if (pool.isGuarded) {
         return getContract(
-          pool.lpToken.addresses[chainId],
+          pool.lpToken,
           LPTOKEN_GUARDED_ABI,
           library,
           account ?? undefined,
         ) as LpTokenGuarded
       } else {
         return getContract(
-          pool.lpToken.addresses[chainId],
+          pool.lpToken,
           LPTOKEN_UNGUARDED_ABI,
           library,
           account ?? undefined,
@@ -317,7 +278,7 @@ export function useLPTokenContract(
       console.error("Failed to get contract", error)
       return null
     }
-  }, [chainId, library, account, poolName])
+  }, [library, pool, account])
 }
 
 interface AllContractsObject {

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -27,6 +27,7 @@ interface TokenShareType {
   value: BigNumber
   decimals: number
   name: string
+  address: string
 }
 
 export interface PoolDataType {
@@ -207,12 +208,14 @@ export default function usePoolData(poolName?: string): PoolDataHookReturnType {
           name: token.name,
           decimals: token.decimals,
           value: priceDataForPool.tokenBalances1e18[i],
+          address: token.address,
         }))
         const userPoolTokens = expandedPoolTokens.map((token, i) => ({
           symbol: token.symbol,
           name: token.name,
           decimals: token.decimals,
           value: userPoolTokenBalances[i],
+          address: token.address,
         }))
         const { oneDayVolume, apy, utilization } =
           swapStats && basicPool.poolAddress in swapStats

--- a/src/hooks/useWithdrawFormState.ts
+++ b/src/hooks/useWithdrawFormState.ts
@@ -37,7 +37,6 @@ export type WithdrawFormAction = {
   fieldName: FormFields | "reset"
   address?: string
   value: string
-  tokenSymbol?: string
 }
 
 export default function useWithdrawFormState(
@@ -285,6 +284,7 @@ export default function useWithdrawFormState(
         let nextState: WithdrawFormState | Record<string, unknown> = {}
         if (action.fieldName === "tokenInputs") {
           const { address = "", value: valueInput } = action
+          console.log({ action })
           const newTokenInputs = {
             ...prevState.tokenInputs,
             [address]: tokenInputStateCreators[address](valueInput),

--- a/src/hooks/useWithdrawFormState.ts
+++ b/src/hooks/useWithdrawFormState.ts
@@ -2,13 +2,14 @@ import {
   NumberInputState,
   numberInputStateCreator,
 } from "../utils/numberInputState"
-import { POOLS_MAP, PoolName, isLegacySwapABIPool } from "../constants"
 import { useCallback, useMemo, useState } from "react"
 
 import { BigNumber } from "@ethersproject/bignumber"
 import { SwapFlashLoan } from "../../types/ethers-contracts/SwapFlashLoan"
 import { SwapFlashLoanNoWithdrawFee } from "../../types/ethers-contracts/SwapFlashLoanNoWithdrawFee"
+import { Zero } from "@ethersproject/constants"
 import { debounce } from "lodash"
+import { isLegacySwapABIPool } from "../constants"
 import { parseUnits } from "@ethersproject/units"
 import { useActiveWeb3React } from "."
 import usePoolData from "../hooks/usePoolData"
@@ -22,7 +23,7 @@ const IMBALANCE = "IMBALANCE"
 const ALL = "ALL"
 
 interface TokenInputs {
-  [symbol: string]: NumberInputState
+  [address: string]: NumberInputState | undefined
 }
 export interface WithdrawFormState {
   percentage: string | null
@@ -34,40 +35,40 @@ export interface WithdrawFormState {
 type FormFields = Exclude<keyof WithdrawFormState, "error">
 export type WithdrawFormAction = {
   fieldName: FormFields | "reset"
-  tokenSymbol?: string
+  address?: string
   value: string
+  tokenSymbol?: string
 }
 
 export default function useWithdrawFormState(
-  poolName: PoolName,
+  poolName: string,
 ): [WithdrawFormState, (action: WithdrawFormAction) => void] {
-  const POOL = POOLS_MAP[poolName]
   const swapContract = useSwapContract(poolName)
-  const [, userShareData] = usePoolData(poolName)
+  const [poolData, userShareData] = usePoolData(poolName)
   const { account } = useActiveWeb3React()
   const tokenInputStateCreators: {
-    [tokenSymbol: string]: ReturnType<typeof numberInputStateCreator>
+    [address: string]: ReturnType<typeof numberInputStateCreator>
   } = useMemo(
     () =>
-      POOL.poolTokens.reduce(
-        (acc, { symbol, decimals }) => ({
+      poolData.tokens.reduce(
+        (acc, { address, decimals }) => ({
           ...acc,
-          [symbol]: numberInputStateCreator(decimals, BigNumber.from("0")),
+          [address]: numberInputStateCreator(decimals, BigNumber.from("0")),
         }),
         {},
       ),
-    [POOL.poolTokens],
+    [poolData.tokens],
   )
   const tokenInputsEmptyState = useMemo(
     () =>
-      POOL.poolTokens.reduce(
-        (acc, { symbol }) => ({
+      poolData.tokens.reduce(
+        (acc, { address }) => ({
           ...acc,
-          [symbol]: tokenInputStateCreators[symbol]("0"),
+          [address]: tokenInputStateCreators[address]("0"),
         }),
         {},
       ),
-    [POOL.poolTokens, tokenInputStateCreators],
+    [poolData.tokens, tokenInputStateCreators],
   )
   const formEmptyState = useMemo(
     () => ({
@@ -107,13 +108,13 @@ export default function useWithdrawFormState(
       if (state.withdrawType === IMBALANCE) {
         try {
           let inputCalculatedLPTokenAmount: BigNumber
-          if (isLegacySwapABIPool(POOL.name)) {
+          if (isLegacySwapABIPool(poolData.name)) {
             inputCalculatedLPTokenAmount = await (
               swapContract as SwapFlashLoan
             ).calculateTokenAmount(
               account,
-              POOL.poolTokens.map(
-                ({ symbol }) => state.tokenInputs[symbol].valueSafe,
+              poolData.tokens.map(
+                ({ address }) => state.tokenInputs[address]?.valueSafe || Zero,
               ),
               false,
             )
@@ -121,8 +122,8 @@ export default function useWithdrawFormState(
             inputCalculatedLPTokenAmount = await (
               swapContract as SwapFlashLoanNoWithdrawFee
             ).calculateTokenAmount(
-              POOL.poolTokens.map(
-                ({ symbol }) => state.tokenInputs[symbol].valueSafe,
+              poolData.tokens.map(
+                ({ address }) => state.tokenInputs[address]?.valueSafe || Zero,
               ),
               false,
             )
@@ -166,10 +167,10 @@ export default function useWithdrawFormState(
           }
           nextState = {
             lpTokenAmountToSpend: effectiveUserLPTokenBalance,
-            tokenInputs: POOL.poolTokens.reduce(
-              (acc, { symbol }, i) => ({
+            tokenInputs: poolData.tokens.reduce(
+              (acc, { address }, i) => ({
                 ...acc,
-                [symbol]: tokenInputStateCreators[symbol](tokenAmounts[i]),
+                [address]: tokenInputStateCreators[address](tokenAmounts[i]),
               }),
               {},
             ),
@@ -186,8 +187,8 @@ export default function useWithdrawFormState(
       } else {
         try {
           if (state.percentage) {
-            const tokenIndex = POOL.poolTokens.findIndex(
-              ({ symbol }) => symbol === state.withdrawType,
+            const tokenIndex = poolData.tokens.findIndex(
+              ({ address }) => address === state.withdrawType,
             )
             let tokenAmount: BigNumber
             if (isLegacySwapABIPool(poolName)) {
@@ -208,10 +209,10 @@ export default function useWithdrawFormState(
             }
             nextState = {
               lpTokenAmountToSpend: effectiveUserLPTokenBalance,
-              tokenInputs: POOL.poolTokens.reduce(
-                (acc, { symbol }, i) => ({
+              tokenInputs: poolData.tokens.reduce(
+                (acc, { address }, i) => ({
                   ...acc,
-                  [symbol]: tokenInputStateCreators[symbol](
+                  [address]: tokenInputStateCreators[address](
                     i === tokenIndex ? tokenAmount : "0",
                   ),
                 }),
@@ -222,13 +223,14 @@ export default function useWithdrawFormState(
           } else {
             // This branch addresses a user manually inputting a value for one token
             let inputCalculatedLPTokenAmount: BigNumber
-            if (isLegacySwapABIPool(POOL.name)) {
+            if (isLegacySwapABIPool(poolData.name)) {
               inputCalculatedLPTokenAmount = await (
                 swapContract as SwapFlashLoan
               ).calculateTokenAmount(
                 account,
-                POOL.poolTokens.map(
-                  ({ symbol }) => state.tokenInputs[symbol].valueSafe,
+                poolData.tokens.map(
+                  ({ address }) =>
+                    state.tokenInputs[address]?.valueSafe || Zero,
                 ),
                 false,
               )
@@ -236,8 +238,9 @@ export default function useWithdrawFormState(
               inputCalculatedLPTokenAmount = await (
                 swapContract as SwapFlashLoanNoWithdrawFee
               ).calculateTokenAmount(
-                POOL.poolTokens.map(
-                  ({ symbol }) => state.tokenInputs[symbol].valueSafe,
+                poolData.tokens.map(
+                  ({ address }) =>
+                    state.tokenInputs[address]?.valueSafe || Zero,
                 ),
                 false,
               )
@@ -271,7 +274,7 @@ export default function useWithdrawFormState(
         ...nextState,
       }))
     }, 250),
-    [userShareData, swapContract, POOL.poolTokens, tokenInputStateCreators],
+    [userShareData, swapContract, poolData.tokens, tokenInputStateCreators],
   )
 
   const handleUpdateForm = useCallback(
@@ -281,21 +284,19 @@ export default function useWithdrawFormState(
       setFormState((prevState) => {
         let nextState: WithdrawFormState | Record<string, unknown> = {}
         if (action.fieldName === "tokenInputs") {
-          const { tokenSymbol: tokenSymbolInput = "", value: valueInput } =
-            action
+          const { address = "", value: valueInput } = action
           const newTokenInputs = {
             ...prevState.tokenInputs,
-            [tokenSymbolInput]:
-              tokenInputStateCreators[tokenSymbolInput](valueInput),
+            [address]: tokenInputStateCreators[address](valueInput),
           }
-          const activeInputTokens = POOL.poolTokens.filter(
-            ({ symbol }) => +newTokenInputs[symbol].valueRaw !== 0,
+          const activeInputTokens = poolData.tokens.filter(
+            ({ address }) => +(newTokenInputs[address]?.valueRaw || "0") !== 0,
           )
           let withdrawType
           if (activeInputTokens.length === 0) {
             withdrawType = ALL
           } else if (activeInputTokens.length === 1) {
-            withdrawType = activeInputTokens[0].symbol
+            withdrawType = activeInputTokens[0].address
           } else {
             withdrawType = IMBALANCE
           }
@@ -340,8 +341,8 @@ export default function useWithdrawFormState(
         }
         const pendingTokenInput =
           action.fieldName === "tokenInputs" &&
-          POOL.poolTokens.every(({ symbol }) => {
-            const stateValue = finalState.tokenInputs[symbol].valueRaw
+          poolData.tokens.every(({ address }) => {
+            const stateValue = finalState.tokenInputs[address]?.valueRaw || Zero
             return isNaN(+stateValue) || +stateValue === 0
           })
         if (!finalState.error && !pendingTokenInput) {
@@ -351,7 +352,7 @@ export default function useWithdrawFormState(
       })
     },
     [
-      POOL.poolTokens,
+      poolData.tokens,
       calculateAndUpdateDynamicFields,
       tokenInputStateCreators,
       tokenInputsEmptyState,

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -188,8 +188,8 @@ function GasAndTokenPrices({
   const fetchAndUpdateSwapStats = useCallback(() => {
     void fetchSwapStats(dispatch)
   }, [dispatch])
-  usePoller(fetchAndUpdateGasPrice, 5 * 1000)
-  usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
+  usePoller(fetchAndUpdateGasPrice, BLOCK_TIME * 5)
+  usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 5)
   usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 280) // ~ 1hr
   return <>{children}</>
 }

--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -4,6 +4,7 @@ import {
   commify,
   formatEther,
   formatUnits,
+  parseEther,
   parseUnits,
 } from "@ethersproject/units"
 
@@ -45,7 +46,12 @@ function Withdraw({ poolName }: Props): ReactElement {
   const tokenInputSum = useMemo(() => {
     return poolData.tokens.reduce(
       (sum, { address }) =>
-        sum.add(withdrawFormState.tokenInputs[address]?.valueSafe || Zero),
+        sum.add(
+          parseEther(
+            "0" +
+              (withdrawFormState.tokenInputs[address]?.valueRaw.trim() || "0"),
+          ) || Zero,
+        ),
       Zero,
     )
   }, [poolData.tokens, withdrawFormState.tokenInputs])
@@ -148,6 +154,7 @@ function Withdraw({ poolName }: Props): ReactElement {
     withdrawLPTokenAmount,
     txnGasCost: txnGasCost,
   }
+  console.log(reviewWithdrawData.priceImpact.toString())
   poolData.tokens.forEach(({ name, decimals, symbol, address }) => {
     if (
       BigNumber.from(

--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -154,7 +154,6 @@ function Withdraw({ poolName }: Props): ReactElement {
     withdrawLPTokenAmount,
     txnGasCost: txnGasCost,
   }
-  console.log(reviewWithdrawData.priceImpact.toString())
   poolData.tokens.forEach(({ name, decimals, symbol, address }) => {
     if (
       BigNumber.from(

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -97,7 +97,7 @@ describe("formatBNToShortString", () => {
 describe("getTokenByAddress", () => {
   it("correctly fetches a token", () => {
     const chainId = 1
-    const target = TOKENS_MAP["SBTC"]
+    const target = TOKENS_MAP["sBTC"]
     expect(getTokenByAddress(target.addresses[chainId], chainId)).toEqual(
       target,
     )

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -97,7 +97,7 @@ describe("formatBNToShortString", () => {
 describe("getTokenByAddress", () => {
   it("correctly fetches a token", () => {
     const chainId = 1
-    const target = TOKENS_MAP["sBTC"]
+    const target = TOKENS_MAP["SBTC"]
     expect(getTokenByAddress(target.addresses[chainId], chainId)).toEqual(
       target,
     )


### PR DESCRIPTION
## Description

As part of the ongoing move from constants to Registry, this PR removes references to `POOLS_MAP`, `TOKENS_MAP`, and `PoolName` from the withdraw flow. Token symbols are also replaced with token addresses.

***IMPORTANT***: For reviewers, please verify any new/migrated contract addresses thoroughly. 

Fixes # (Add link to github issue if available)

_Note_: If merged/deployed alone, make that known in a public Slack channel and ping team members. If the description above is clear and concise, it should be sufficient for team members with minimal context to verify the work that was done. Otherwise, please revise and provide additional information.

## Post merge/deploy:

- [ ] Manually verify (preferably with another team member) that the shipped changes are on prod. 