### PR TITLE
Add Snapshot voting links to veSDL page

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -189,10 +189,6 @@ function PricesAndVoteData({
   const fetchAndUpdateSwapStats = useCallback(() => {
     void fetchSwapStats(dispatch)
   }, [dispatch])
-<<<<<<< HEAD
-  usePoller(fetchAndUpdateGasPrice, BLOCK_TIME * 5)
-  usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 5)
-=======
 
   useEffect(() => {
     void getSnapshotVoteData(dispatch)
@@ -200,7 +196,6 @@ function PricesAndVoteData({
 
   usePoller(fetchAndUpdateGasPrice, 5 * 1000)
   usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
->>>>>>> 3594abe (Added redux state for Snapshot vote data and all necessary reducers and actions)
   usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 280) // ~ 1hr
   return <>{children}</>
 }

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -36,6 +36,7 @@ import WrongNetworkModal from "../components/WrongNetworkModal"
 import fetchGasPrices from "../utils/updateGasPrices"
 import fetchSwapStats from "../utils/getSwapStats"
 import fetchTokenPricesUSD from "../utils/updateTokenPrices"
+import getSnapshotVoteData from "../utils/getSnapshotVoteData"
 import { useActiveWeb3React } from "../hooks"
 import { useDispatch } from "react-redux"
 import { useIntercom } from "react-use-intercom"
@@ -84,7 +85,7 @@ export default function App(): ReactElement {
             <GaugeProvider>
               <TokensProvider>
                 <UserStateProvider>
-                  <GasAndTokenPrices>
+                  <PricesAndVoteData>
                     <PendingSwapsProvider>
                       <RewardsBalancesProvider>
                         <LocalizationProvider dateAdapter={AdapterDateFns}>
@@ -162,7 +163,7 @@ export default function App(): ReactElement {
                         </LocalizationProvider>
                       </RewardsBalancesProvider>
                     </PendingSwapsProvider>
-                  </GasAndTokenPrices>
+                  </PricesAndVoteData>
                 </UserStateProvider>
               </TokensProvider>
             </GaugeProvider>
@@ -173,7 +174,7 @@ export default function App(): ReactElement {
   )
 }
 
-function GasAndTokenPrices({
+function PricesAndVoteData({
   children,
 }: React.PropsWithChildren<unknown>): ReactElement {
   const dispatch = useDispatch<AppDispatch>()
@@ -188,8 +189,18 @@ function GasAndTokenPrices({
   const fetchAndUpdateSwapStats = useCallback(() => {
     void fetchSwapStats(dispatch)
   }, [dispatch])
+<<<<<<< HEAD
   usePoller(fetchAndUpdateGasPrice, BLOCK_TIME * 5)
   usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 5)
+=======
+
+  useEffect(() => {
+    void getSnapshotVoteData(dispatch)
+  }, [dispatch])
+
+  usePoller(fetchAndUpdateGasPrice, 5 * 1000)
+  usePoller(fetchAndUpdateTokensPrice, BLOCK_TIME * 3)
+>>>>>>> 3594abe (Added redux state for Snapshot vote data and all necessary reducers and actions)
   usePoller(fetchAndUpdateSwapStats, BLOCK_TIME * 280) // ~ 1hr
   return <>{children}</>
 }

--- a/src/pages/VeSDL/GaugeVote.tsx
+++ b/src/pages/VeSDL/GaugeVote.tsx
@@ -21,6 +21,7 @@ import {
 import { AppState } from "../../state"
 import { GaugeContext } from "../../providers/GaugeProvider"
 import GaugeWeight from "../../components/GaugeWeight"
+import { generateSnapshotVoteLink } from "../../utils"
 import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
 
@@ -88,18 +89,10 @@ export default function GaugeVote(): JSX.Element {
         </Table>
       </TableContainer>
       <Typography textAlign="end" mt={1}>
-        <Link
-          color="inherit"
-          href="https://snapshot.org/#/saddlefinance.eth"
-          target="_blank"
-        >
+        <Link color="inherit" href={generateSnapshotVoteLink()} target="_blank">
           {t("viewAllVote")}
         </Link>
       </Typography>
     </Paper>
   )
-}
-
-function generateSnapshotVoteLink(id: string): string {
-  return `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
 }

--- a/src/pages/VeSDL/GaugeVote.tsx
+++ b/src/pages/VeSDL/GaugeVote.tsx
@@ -1,5 +1,6 @@
 import {
   Box,
+  /* eslint-disable @typescript-eslint/no-unused-vars */
   Button,
   CircularProgress,
   Link,
@@ -13,12 +14,22 @@ import {
   Typography,
 } from "@mui/material"
 import React, { useContext } from "react"
+import {
+  SNAPSHOT_STATE,
+  VoteEscrowSnapshots,
+} from "../../state/voteEscrowSnapshots"
+import { AppState } from "../../state"
 import { GaugeContext } from "../../providers/GaugeProvider"
 import GaugeWeight from "../../components/GaugeWeight"
+import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
 
 export default function GaugeVote(): JSX.Element {
   const gaugeData = useContext(GaugeContext)
+  const { snapshots }: VoteEscrowSnapshots = useSelector(
+    (state: AppState) => state.voteEscrowSnapshots,
+  )
+
   const { t } = useTranslation()
   return (
     <Paper sx={{ p: 2 }}>
@@ -50,20 +61,45 @@ export default function GaugeVote(): JSX.Element {
             </TableRow>
           </TableHead>
           <TableBody>
-            <TableRow>
-              <TableCell>{t("currentWeek")}</TableCell>
-              <TableCell align="center">
-                <Button variant="contained" size="medium">
-                  <Typography>{t("vote")}</Typography>
-                </Button>
-              </TableCell>
-            </TableRow>
+            {snapshots.map((snapshot, index) => {
+              const voteOrView =
+                snapshot.state === SNAPSHOT_STATE.CLOSED
+                  ? t("results")
+                  : t("vote")
+              return (
+                <TableRow key={`snapshot-${index}`}>
+                  <TableCell>
+                    {new Date(snapshot.start * 1000).toLocaleDateString()}
+                  </TableCell>
+                  <TableCell align="center">
+                    <Button
+                      variant="contained"
+                      size="medium"
+                      href={generateSnapshotVoteLink(snapshot.id)}
+                      target="_blank"
+                    >
+                      <Typography>{voteOrView}</Typography>
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              )
+            })}
           </TableBody>
         </Table>
       </TableContainer>
       <Typography textAlign="end" mt={1}>
-        <Link color="inherit">{t("viewAllVote")}</Link>
+        <Link
+          color="inherit"
+          href="https://snapshot.org/#/saddlefinance.eth"
+          target="_blank"
+        >
+          {t("viewAllVote")}
+        </Link>
       </Typography>
     </Paper>
   )
+}
+
+function generateSnapshotVoteLink(id: string): string {
+  return `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
 }

--- a/src/pages/VeSDL/GaugeVote.tsx
+++ b/src/pages/VeSDL/GaugeVote.tsx
@@ -1,6 +1,5 @@
 import {
   Box,
-  /* eslint-disable @typescript-eslint/no-unused-vars */
   Button,
   CircularProgress,
   Link,

--- a/src/providers/GaugeProvider.tsx
+++ b/src/providers/GaugeProvider.tsx
@@ -55,7 +55,6 @@ export default function GaugeProvider({
       const gauges: Gauges =
         (await getGaugeData(library, chainId, gaugeController)) ||
         initialGaugesState
-
       setGauges(gauges)
     }
 

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -4,6 +4,7 @@ import user, { initialState as userInitialState } from "./user"
 
 import application from "./application"
 import { merge } from "lodash"
+import voteEscrowSnapshots from "./voteEscrowSnapshots"
 
 const PERSISTED_KEYS: string[] = ["user"]
 const stateFromStorage = load({
@@ -12,6 +13,7 @@ const stateFromStorage = load({
 const reducer = {
   application,
   user,
+  voteEscrowSnapshots,
 }
 const store = configureStore({
   reducer,

--- a/src/state/voteEscrowSnapshots.ts
+++ b/src/state/voteEscrowSnapshots.ts
@@ -24,15 +24,15 @@ const voteEscrowSnapshotsSlice = createSlice({
   name: "voteEscrowSnapshots",
   initialState,
   reducers: {
-    getVoteEscrowSnapshots(
+    updateVoteEscrowSnapshots(
       state,
       action: PayloadAction<VoteEscrowSnapshots>,
     ): void {
-      state.snapshots = [...state.snapshots, ...action.payload.snapshots]
+      state.snapshots = action.payload.snapshots
     },
   },
 })
 
-export const { getVoteEscrowSnapshots } = voteEscrowSnapshotsSlice.actions
+export const { updateVoteEscrowSnapshots } = voteEscrowSnapshotsSlice.actions
 
 export default voteEscrowSnapshotsSlice.reducer

--- a/src/state/voteEscrowSnapshots.ts
+++ b/src/state/voteEscrowSnapshots.ts
@@ -1,0 +1,38 @@
+import { PayloadAction, createSlice } from "@reduxjs/toolkit"
+
+export enum SNAPSHOT_STATE {
+  OPEN = "open",
+  CLOSED = "closed",
+}
+
+export type Proposal = {
+  id: string
+  start: number
+  state: SNAPSHOT_STATE
+  title: string
+}
+
+export interface VoteEscrowSnapshots {
+  snapshots: Proposal[]
+}
+
+const initialState: VoteEscrowSnapshots = {
+  snapshots: [],
+}
+
+const voteEscrowSnapshotsSlice = createSlice({
+  name: "voteEscrowSnapshots",
+  initialState,
+  reducers: {
+    getVoteEscrowSnapshots(
+      state,
+      action: PayloadAction<VoteEscrowSnapshots>,
+    ): void {
+      state.snapshots = [...state.snapshots, ...action.payload.snapshots]
+    },
+  },
+})
+
+export const { getVoteEscrowSnapshots } = voteEscrowSnapshotsSlice.actions
+
+export default voteEscrowSnapshotsSlice.reducer

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -9,6 +9,7 @@ import {
   enumerate,
   formatBNToShortString,
   formatDeadlineToNumber,
+  generateSnapshotVoteLink,
   getTokenByAddress,
   getTokenIconPath,
   getTokenSymbolForPoolType,
@@ -227,5 +228,13 @@ describe("createMultiCallContrat", () => {
     expect(
       helperContractMultiCall.gaugeToPoolAddress(emptyAddress),
     ).toBeInstanceOf(Object)
+  })
+})
+
+describe("generateSnapshotVoteLink", () => {
+  it("correctly generates a snapshot link from id", () => {
+    const id = "0x0000000000000000000000000000000000000000"
+    const expectedLink = `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
+    expect(generateSnapshotVoteLink(id)).toEqual(expectedLink)
   })
 })

--- a/src/utils/__tests__/index.ts
+++ b/src/utils/__tests__/index.ts
@@ -237,4 +237,9 @@ describe("generateSnapshotVoteLink", () => {
     const expectedLink = `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
     expect(generateSnapshotVoteLink(id)).toEqual(expectedLink)
   })
+
+  it("returns link to all proposals if id is not present", () => {
+    const expectedLink = `https://snapshot.org/#/saddlefinance.eth`
+    expect(generateSnapshotVoteLink()).toEqual(expectedLink)
+  })
 })

--- a/src/utils/getSnapshotVoteData.ts
+++ b/src/utils/getSnapshotVoteData.ts
@@ -1,8 +1,4 @@
-import {
-  Proposal,
-  VoteEscrowSnapshots,
-  getVoteEscrowSnapshots,
-} from "../state/voteEscrowSnapshots"
+import { Proposal, getVoteEscrowSnapshots } from "../state/voteEscrowSnapshots"
 import { AppDispatch } from "../state"
 
 interface Response {
@@ -51,27 +47,14 @@ export default function getSnapshotVoteData(
         .slice(0, 10),
     )
     .then((proposals) => {
-      const voteEscrowSnapshots = extractSnapshotInfoFromProposals(proposals)
-      dispatch(getVoteEscrowSnapshots(voteEscrowSnapshots))
+      dispatch(getVoteEscrowSnapshots({ snapshots: proposals }))
     })
-}
-
-function extractSnapshotInfoFromProposals(
-  proposals: Proposal[],
-): VoteEscrowSnapshots {
-  const voteEscrowSnapshots: VoteEscrowSnapshots = {
-    snapshots: [],
-  }
-
-  voteEscrowSnapshots.snapshots = proposals.map(
-    ({ id, start, state, title }) => {
-      return {
-        id,
-        start,
-        state,
-        title,
-      }
-    },
-  )
-  return voteEscrowSnapshots
+    .catch((e) => {
+      const error = new Error(
+        `Unable to get Snapshot vote data \n${(e as Error).message}`,
+      )
+      error.stack = (e as Error).stack
+      console.error(error)
+      return Promise.resolve()
+    })
 }

--- a/src/utils/getSnapshotVoteData.ts
+++ b/src/utils/getSnapshotVoteData.ts
@@ -1,4 +1,7 @@
-import { Proposal, getVoteEscrowSnapshots } from "../state/voteEscrowSnapshots"
+import {
+  Proposal,
+  updateVoteEscrowSnapshots,
+} from "../state/voteEscrowSnapshots"
 import { AppDispatch } from "../state"
 
 interface Response {
@@ -47,7 +50,7 @@ export default function getSnapshotVoteData(
         .slice(0, 10),
     )
     .then((proposals) => {
-      dispatch(getVoteEscrowSnapshots({ snapshots: proposals }))
+      dispatch(updateVoteEscrowSnapshots({ snapshots: proposals }))
     })
     .catch((e) => {
       const error = new Error(

--- a/src/utils/getSnapshotVoteData.ts
+++ b/src/utils/getSnapshotVoteData.ts
@@ -1,0 +1,77 @@
+import {
+  Proposal,
+  VoteEscrowSnapshots,
+  getVoteEscrowSnapshots,
+} from "../state/voteEscrowSnapshots"
+import { AppDispatch } from "../state"
+
+interface Response {
+  data: {
+    proposals: Proposal[]
+  }
+}
+
+export default function getSnapshotVoteData(
+  dispatch: AppDispatch,
+): Promise<void> {
+  const SNAPSHOT_API_URL = "https://hub.snapshot.org/graphql"
+  /**
+   * If more fields are needed, refer to https://docs.snapshot.org/graphql-api#proposals
+   * and add them into the query below
+   */
+  const query = `{
+    proposals (
+      first: 20,
+      skip: 0,
+      where: {
+        space_in: ["saddlefinance.eth"],
+      },
+      orderBy: "created",
+      orderDirection: desc
+    ) {
+      id
+      title
+      start
+      state
+    }
+  }`
+
+  return fetch(SNAPSHOT_API_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ query }),
+  })
+    .then((res) => res.json())
+    .then((result: Response) =>
+      result.data.proposals
+        .filter((proposal) =>
+          proposal.title.toLowerCase().includes("gauge reward allocation vote"),
+        )
+        // Only grab the first 10
+        .slice(0, 10),
+    )
+    .then((proposals) => {
+      const voteEscrowSnapshots = extractSnapshotInfoFromProposals(proposals)
+      dispatch(getVoteEscrowSnapshots(voteEscrowSnapshots))
+    })
+}
+
+function extractSnapshotInfoFromProposals(
+  proposals: Proposal[],
+): VoteEscrowSnapshots {
+  const voteEscrowSnapshots: VoteEscrowSnapshots = {
+    snapshots: [],
+  }
+
+  voteEscrowSnapshots.snapshots = proposals.map(
+    ({ id, start, state, title }) => {
+      return {
+        id,
+        start,
+        state,
+        title,
+      }
+    },
+  )
+  return voteEscrowSnapshots
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -402,3 +402,13 @@ export function createMultiCallContract<T>(
     contractAbi,
   ) as MulticallContract<T>
 }
+
+/**
+ * Generate the snapshot vote URL from ID
+ *
+ * @param id ID of snapshot
+ * @returns the snapshot URL
+ */
+export function generateSnapshotVoteLink(id: string): string {
+  return `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -409,6 +409,7 @@ export function createMultiCallContract<T>(
  * @param id ID of snapshot
  * @returns the snapshot URL
  */
-export function generateSnapshotVoteLink(id: string): string {
-  return `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
+export function generateSnapshotVoteLink(id?: string): string {
+  if (id) return `https://snapshot.org/#/saddlefinance.eth/proposal/${id}`
+  return "https://snapshot.org/#/saddlefinance.eth"
 }


### PR DESCRIPTION
***Description:*** As part of the veSDL Gauge component page, there will be a table with links to the snapshot voting underneath the PieChart. It will have the voting period as the title and a button that links to the snapshot voting page. The data is fetched from the Snapshot GraphQL API and added to a key in the redux store that is rendered only once on page load. 
*Notes*:
- Only 10 entries are rendered, but can be changed if need be. 
- GraphQL calls only are getting the `id, title, start, state`. Can add extra fields later if needed
- If the state of the snapshot voting is still ongoing, the Button will show up as `vote`.
- If the state of the snapshot voting is closed, the Button will show up as `results`.
- The `View all votes` links to [https://snapshot.org/#/saddlefinance.eth/](url)

![Screen Shot 2022-05-13 at 1 27 42 PM](https://user-images.githubusercontent.com/24193788/168385228-f9439245-3f1a-40fa-87c6-ced3b6aa9f5b.png)
