### PR TITLE
Add Gauge Rewards

### DIFF
--- a/src/constants/abis/helperContract.json
+++ b/src/constants/abis/helperContract.json
@@ -135,5 +135,80 @@
     ],
     "stateMutability": "view",
     "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "gauge",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      }
+    ],
+    "name": "getClaimableRewards",
+    "outputs": [
+      {
+        "internalType": "uint256[]",
+        "name": "",
+        "type": "uint256[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "gauge",
+        "type": "address"
+      }
+    ],
+    "name": "getGaugeRewards",
+    "outputs": [
+      {
+        "components": [
+          {
+            "internalType": "address",
+            "name": "token",
+            "type": "address"
+          },
+          {
+            "internalType": "address",
+            "name": "distributor",
+            "type": "address"
+          },
+          {
+            "internalType": "uint256",
+            "name": "period_finish",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "rate",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "last_update",
+            "type": "uint256"
+          },
+          {
+            "internalType": "uint256",
+            "name": "integral",
+            "type": "uint256"
+          }
+        ],
+        "internalType": "struct ILiquidityGaugeV5.Reward[]",
+        "name": "",
+        "type": "tuple[]"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
   }
 ]

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -475,7 +475,7 @@ export const HELPER_CONTRACT_ADDRESSES = buildAddresses({
 })
 
 export const GAUGE_CONTROLLER_ADDRESSES = buildAddresses({
-  [ChainId.HARDHAT]: "0xc0F115A19107322cFBf1cDBC7ea011C19EbDB4F8",
+  [ChainId.HARDHAT]: "0xF8e31cb472bc70500f08Cd84917E5A1912Ec8397",
 })
 
 export const SPA = new Token(

--- a/src/providers/GaugeProvider.tsx
+++ b/src/providers/GaugeProvider.tsx
@@ -151,8 +151,8 @@ export async function getGaugeData(
             gaugeWeight: gaugeWeights[index],
             gaugeRelativeWeight: gaugeRelativeWeights[index],
             rewards: gaugeRewards[index].map((reward) => ({
-              period_finish: reward.period_finish,
-              last_update: reward.last_update,
+              periodFinish: reward.period_finish,
+              lastUpdate: reward.last_update,
               distributor: reward.distributor.toLowerCase(),
               rate: reward.rate,
               token: reward.token.toLowerCase(),

--- a/src/providers/TokensProvider.tsx
+++ b/src/providers/TokensProvider.tsx
@@ -1,4 +1,5 @@
 import { BasicPool, BasicPoolsContext } from "./BasicPoolsProvider"
+import { Gauge, GaugeContext } from "./GaugeProvider"
 import {
   MulticallCall,
   MulticallContract,
@@ -31,6 +32,7 @@ export default function TokensProvider({
   const { chainId, library } = useActiveWeb3React()
   const pools = useContext(BasicPoolsContext)
   const minichefData = useContext(MinichefContext)
+  const gauges = useContext(GaugeContext)
   const [tokens, setTokens] = useState<BasicTokens>(null)
   useEffect(() => {
     async function fetchTokens() {
@@ -58,6 +60,14 @@ export default function TokensProvider({
           targetTokenAddresses.add(address)
         })
       }
+      if (gauges.gauges) {
+        // add gauge tokens
+        ;(Object.values(gauges.gauges) as Gauge[]).forEach((gauge) => {
+          gauge.rewards.forEach(({ token }) => {
+            targetTokenAddresses.add(token)
+          })
+        })
+      }
       const tokenInfos = await getTokenInfos(
         ethCallProvider,
         chainId,
@@ -70,7 +80,7 @@ export default function TokensProvider({
       setTokens(tokenInfos)
     }
     void fetchTokens()
-  }, [chainId, library, pools, minichefData])
+  }, [chainId, library, pools, minichefData, gauges.gauges])
   return (
     <TokensContext.Provider value={tokens}>{children}</TokensContext.Provider>
   )


### PR DESCRIPTION
Adds gauge rewards to the gauge provider, as well as including them in the tokens provider for fetching token info.

To test locally, start your local evm, then run `npx hardhat run scripts/checkGaugeRewards.ts --network localhost` to create rewards 

<img width="1354" alt="Screen Shot 2022-05-17 at 2 42 59 PM" src="https://user-images.githubusercontent.com/7607886/168915030-742b2bb4-c5a6-4184-89cb-221c995bef07.png">


@ug02fast 