### PR TITLE
Add correct ethcall tryEach types based on canFail

### DIFF
--- a/src/types/ethcall.d.ts
+++ b/src/types/ethcall.d.ts
@@ -51,38 +51,68 @@ export class MulticallProvider extends Provider {
     block?: number,
   ): Promise<[A["outputs"], B["outputs"], C["outputs"], D["outputs"]]>
   all<O>(calls: MulticallCall<I, O>[], block?: number): Promise<O[]> // fallthrough to array type
-  tryEach<A extends MulticallCall>(
+  tryEach<A extends MulticallCall, CanFailA extends boolean>(
     calls: readonly [A],
-    canFail: boolean[],
+    canFail: [CanFailA],
     block?: number,
-  ): Promise<[A["outputs"]]>
-  tryEach<A extends MulticallCall, B extends MulticallCall>(
+  ): Promise<[CanFailA extends true ? A["outputs"] | null : A["outputs"]]>
+  tryEach<
+    A extends MulticallCall,
+    B extends MulticallCall,
+    CanFailA extends boolean,
+    CanFailB extends boolean,
+  >(
     calls: readonly [A, B],
-    canFail: boolean[],
+    canFail: [CanFailA, CanFailB],
     block?: number,
-  ): Promise<[A["outputs"], B["outputs"]]>
+  ): Promise<
+    [
+      CanFailA extends true ? A["outputs"] | null : A["outputs"],
+      CanFailB extends true ? B["outputs"] | null : B["outputs"],
+    ]
+  >
   tryEach<
     A extends MulticallCall,
     B extends MulticallCall,
     C extends MulticallCall,
+    CanFailA extends boolean,
+    CanFailB extends boolean,
+    CanFailC extends boolean,
   >(
     calls: readonly [A, B, C],
-    canFail: boolean[],
+    canFail: [CanFailA, CanFailB, CanFailC],
     block?: number,
-  ): Promise<[A["outputs"], B["outputs"], C["outputs"]]>
+  ): Promise<
+    [
+      CanFailA extends true ? A["outputs"] | null : A["outputs"],
+      CanFailB extends true ? B["outputs"] | null : B["outputs"],
+      CanFailC extends true ? C["outputs"] | null : C["outputs"],
+    ]
+  >
   tryEach<
     A extends MulticallCall,
     B extends MulticallCall,
     C extends MulticallCall,
     D extends MulticallCall,
+    CanFailA extends boolean,
+    CanFailB extends boolean,
+    CanFailC extends boolean,
+    CanFailD extends boolean,
   >(
     calls: readonly [A, B, C, D],
-    canFail: boolean[],
+    canFail: [CanFailA, CanFailB, CanFailC, CanFailD],
     block?: number,
-  ): Promise<[A["outputs"], B["outputs"], C["outputs"], D["outputs"]]>
-  tryEach<O>(
+  ): Promise<
+    [
+      CanFailA extends true ? A["outputs"] | null : A["outputs"],
+      CanFailB extends true ? B["outputs"] | null : B["outputs"],
+      CanFailC extends true ? C["outputs"] | null : C["outputs"],
+      CanFailD extends true ? D["outputs"] | null : D["outputs"],
+    ]
+  >
+  tryEach<O, CanFailO extends boolean>(
     calls: MulticallCall<I, O>[],
-    canFail: boolean[],
+    canFail: CanFailO[],
     block?: number,
-  ): Promise<O[]> // fallthrough to array type
+  ): Promise<(CanFailO extends true ? O | null : O)[]> // fallthrough to array type
 }

--- a/src/utils/migrations.ts
+++ b/src/utils/migrations.ts
@@ -37,7 +37,7 @@ export async function getMigrationData(
     )
     const results = await ethCallProvider.tryEach(
       calls,
-      Array(calls.length).fill(true),
+      Array(calls.length).fill(true) as true[],
     )
     const parsedData = poolAddresses.reduce((acc, address, i) => {
       const result = results[i]?.newPoolAddress

--- a/src/utils/minichef.ts
+++ b/src/utils/minichef.ts
@@ -153,7 +153,7 @@ export async function getMinichefRewardsRewardersData(
     )
     const rewarderContractsMap = {} as { [pid: number]: IRewarder }
     rewarderAddresses.forEach((address, i) => {
-      if (address !== AddressZero) {
+      if (address && address !== AddressZero) {
         const pid = addressesPidTuples[i][1]
         rewarderContractsMap[pid] = new Contract(
           address,
@@ -223,6 +223,7 @@ export async function getMinichefRewardsUserData(
     )
     return userPoolsInfo.reduce((acc, poolInfo, i) => {
       const [, pid] = addressesPidTuples[i]
+      if (!poolInfo) return acc
       return {
         ...acc,
         [pid]: {

--- a/src/utils/thirdPartyIntegrations.ts
+++ b/src/utils/thirdPartyIntegrations.ts
@@ -182,7 +182,7 @@ async function getSharedStakeData(
     userStakedAmount,
   ] = await ethcallProvider.tryEach(
     multicalls,
-    multicalls.map(() => false),
+    multicalls.map(() => false) as false[],
   )
   const nowSeconds = BigNumber.from(Math.floor(Date.now() / 1000))
   const remainingDays = until.sub(nowSeconds).div(60 * 60 * 24) // 1e0
@@ -243,7 +243,7 @@ async function getAlEthData(
   const [alcxRewardPerBlock, poolTotalDeposited, userStakedAmount] =
     await ethcallProvider.tryEach(
       multicalls,
-      multicalls.map(() => false),
+      multicalls.map(() => false) as false[],
     )
   const alcxPerYear = alcxRewardPerBlock.mul(52 * 45000) // 1e18 // blocks/year rate from Alchemix's own logic
   const alcxPerYearUSD = alcxPerYear.mul(parseUnits(alcxPrice.toFixed(2), 2)) // 1e20


### PR DESCRIPTION

Before: 
```
const foo = await multicallProvider.tryEach([getName], [false]) // type: [string]
const foo = await multicallProvider.tryEach([getName], [true]) // also type: [string]
```

After: 
```
const foo = await multicallProvider.tryEach([getName], [false]) // type: [string]
const foo = await multicallProvider.tryEach([getName], [true]) //  type: [string | null]
```

Closes #1045 