### PR TITLE
fix for metaswap tests

### DIFF
--- a/cypress/integration/deposit.test.ts
+++ b/cypress/integration/deposit.test.ts
@@ -1,7 +1,23 @@
+import { JsonRpcProvider } from "@ethersproject/providers"
+import { getDefaultProvider } from "ethers"
+
 const STABLECOIN_POOL_V2_NAME = "Stablecoin V2"
 const SUSD_METAPOOL_V3_NAME = "sUSD-USDv2_v3"
 const pools = [STABLECOIN_POOL_V2_NAME, SUSD_METAPOOL_V3_NAME] // order is important basepool must have balance prior to metapool
 
+async function increaseTime() {
+  const provider = getDefaultProvider(
+    Cypress.env("PROVIDER_HOST"),
+  ) as JsonRpcProvider
+  // move block time forward +10 minutes
+  // this is necessary since metapools have a 10 minute cache of base pool virtualPrice
+  return new Cypress.Promise((resolve) => {
+    void provider
+      .send("evm_increaseTime", [600]) // +10 minutes
+      .then(() => provider.send("evm_mine", []))
+      .then(resolve)
+  })
+}
 context("Deposit Flow", () => {
   beforeEach(() => {
     cy.visit(`/#/pools`)
@@ -9,6 +25,9 @@ context("Deposit Flow", () => {
   })
 
   function testPoolDeposit(poolName: string) {
+    if (poolName === SUSD_METAPOOL_V3_NAME) {
+      void increaseTime()
+    }
     it(`successfully completes a deposit of all ${poolName} assets`, () => {
       cy.contains(poolName)
         .parents("[data-testid=poolOverview]")


### PR DESCRIPTION
add 10 minutes to evm time after basepool deposit to bust metapool cache
https://saddle-finance.slack.com/archives/C017XJU4GSJ/p1653459974141809?thread_ts=1653355453.867859&cid=C017XJU4GSJ