### PR TITLE
Use better type for Object.values for maybe undefined values

### DIFF
--- a/scripts/unpauseEvmos.js
+++ b/scripts/unpauseEvmos.js
@@ -1,0 +1,18 @@
+const ethers = require("ethers")
+const META_SWAP_ABI = require("../src/constants/abis/metaSwap.json")
+
+const { Contract, Wallet, providers } = ethers
+const poolAddress = "0xdb5c5A6162115Ce9a188E7D773C4D011F421BbE5"
+const provider = new providers.JsonRpcProvider(
+  "https://eth.bd.evmos.org:8545",
+  9001,
+)
+const signer = new Wallet("0x" + process.env.DEPLOYER_PRIVATE_KEY, provider)
+const metaSwapContract = new Contract(poolAddress, META_SWAP_ABI, signer)
+;(async function main() {
+  console.log(`Unpausing ${metaSwapContract.address}`)
+  const txn = await metaSwapContract.unpause()
+  const result = await txn.wait()
+  console.log(result)
+  console.log(`Unpaused ${metaSwapContract.address}`)
+})()

--- a/src/components/GaugeWeight.tsx
+++ b/src/components/GaugeWeight.tsx
@@ -1,7 +1,7 @@
-import { BasicPool, BasicPoolsContext } from "../providers/BasicPoolsProvider"
 import { CircularProgress, useTheme } from "@mui/material"
 import React, { useContext, useRef } from "react"
 
+import { BasicPoolsContext } from "../providers/BasicPoolsProvider"
 import { BigNumber } from "@ethersproject/bignumber"
 import Highcharts from "highcharts"
 import HighchartsExporting from "highcharts/modules/exporting"
@@ -25,11 +25,11 @@ export default function GaugeWeight({
 }: Props & HighchartsReact.Props): JSX.Element {
   HighchartsExporting(Highcharts)
   const chartComponentRef = useRef<HighchartsReact.RefObject>(null)
-  const pools = useContext(BasicPoolsContext)
+  const basicPools = useContext(BasicPoolsContext)
   const theme = useTheme()
-  if (pools == undefined) return <CircularProgress color="secondary" />
+  if (basicPools == undefined) return <CircularProgress color="secondary" />
 
-  const gaugesInfo = (Object.values(pools) as BasicPool[])
+  const gaugesInfo = Object.values(basicPools)
     .map((pool) => {
       const gaugePoolAddress = pool.poolAddress
       const gauge = gauges[gaugePoolAddress]

--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -74,7 +74,7 @@ export default function TokenClaimDialog({
   )
   const [allPoolsWithRewards, poolsWithUserRewards] = useMemo(() => {
     if (!basicPools) return [[], []]
-    const allPoolsWithRewards = (Object.values(basicPools) as BasicPool[])
+    const allPoolsWithRewards = Object.values(basicPools)
       .filter(({ miniChefRewardsPid }) => {
         // remove pools not in this chain and without rewards
         return miniChefRewardsPid !== null

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -81,7 +81,7 @@ export default function Transactions(): ReactElement {
   const [transactionList, setTransactionList] = useState<Transaction[]>([])
   const basicPoolsByAddress = useMemo(
     () =>
-      (Object.values(basicPools || {}) as BasicPool[]).reduce(
+      Object.values(basicPools || {}).reduce(
         (acc, basicPool) => ({ ...acc, [basicPool.poolAddress]: basicPool }),
         {} as { [address: string]: BasicPool },
       ),

--- a/src/hooks/useCalculateSwapPairs.ts
+++ b/src/hooks/useCalculateSwapPairs.ts
@@ -43,7 +43,7 @@ export function useCalculateSwapPairs(): (token?: Token) => SwapData[] {
   const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
   const [poolsSortedByTVL, tokenToPoolsMapSorted] = useMemo(() => {
     if (basicPools === null || tokens === null) return []
-    const basicPoolsWithPriceData = (Object.values(basicPools) as BasicPool[])
+    const basicPoolsWithPriceData = Object.values(basicPools)
       .map((pool) => {
         const priceData = getPriceDataForPool(tokens, pool, tokenPricesUSD)
         const expandedTokens = pool.tokens.map((addr) => tokens?.[addr])
@@ -170,7 +170,7 @@ function getTradingPairsForToken(
       (acc, pool) => ({ ...acc, [pool.poolName]: pool }),
       {},
     )
-  const allTokens = (Object.values(tokensMap) as BasicToken[]).filter(
+  const allTokens = Object.values(tokensMap).filter(
     ({ isLPToken, address }) => !isLPToken && tokenToPoolsMap[address],
   ) // @dev tokens includes non-pool tokens like rewards as well, so filter only tokens in pools
   const synthPoolsSet = new Set(

--- a/src/pages/Pools.tsx
+++ b/src/pages/Pools.tsx
@@ -1,8 +1,8 @@
-import { BasicPool, BasicPoolsContext } from "../providers/BasicPoolsProvider"
 import { Box, Button, Chip, Container, Stack, TextField } from "@mui/material"
 import React, { ReactElement, useContext, useEffect, useState } from "react"
 
 import { AppState } from "../state"
+import { BasicPoolsContext } from "../providers/BasicPoolsProvider"
 import { BigNumber } from "ethers"
 import ConfirmTransaction from "../components/ConfirmTransaction"
 import Dialog from "../components/Dialog"
@@ -101,7 +101,7 @@ function Pools(): ReactElement | null {
       </Stack>
 
       <Stack spacing={3}>
-        {(Object.values(basicPools || {}) as BasicPool[])
+        {Object.values(basicPools || {})
           .filter(
             (basicPool) =>
               filter === "all" ||

--- a/src/providers/MinichefProvider.tsx
+++ b/src/providers/MinichefProvider.tsx
@@ -1,7 +1,7 @@
-import { BasicPool, BasicPoolsContext } from "./BasicPoolsProvider"
 import { MinichefData, getMinichefRewardsPoolsData } from "../utils/minichef"
 import React, { ReactElement, useContext, useEffect, useState } from "react"
 
+import { BasicPoolsContext } from "./BasicPoolsProvider"
 import { useActiveWeb3React } from "../hooks"
 
 export const MinichefContext = React.createContext<MinichefData | null>(null)
@@ -18,7 +18,7 @@ export default function MinichefProvider({
         setRewardsData(null)
         return
       }
-      const poolAddresses = (Object.values(pools || {}) as BasicPool[]).map(
+      const poolAddresses = Object.values(pools || {}).map(
         ({ poolAddress }) => poolAddress,
       )
       const rewardsData = await getMinichefRewardsPoolsData(

--- a/src/providers/RewardsBalancesProvider.tsx
+++ b/src/providers/RewardsBalancesProvider.tsx
@@ -1,4 +1,3 @@
-import { BasicPool, BasicPoolsContext } from "./BasicPoolsProvider"
 import React, {
   ReactElement,
   useCallback,
@@ -9,6 +8,7 @@ import React, {
 } from "react"
 
 import { BLOCK_TIME } from "../constants"
+import { BasicPoolsContext } from "./BasicPoolsProvider"
 import { BigNumber } from "@ethersproject/bignumber"
 import { UserStateContext } from "./UserStateProvider"
 import { Zero } from "@ethersproject/constants"
@@ -127,7 +127,7 @@ function usePoolsRewardBalances() {
     if (!userState || !basicPools) {
       return
     }
-    const poolsWithRewards = (Object.values(basicPools) as BasicPool[]).filter(
+    const poolsWithRewards = Object.values(basicPools).filter(
       ({ miniChefRewardsPid }) => miniChefRewardsPid != null,
     )
     const poolNameToMinichefSDLBalance = poolsWithRewards.reduce(

--- a/src/providers/TokensProvider.tsx
+++ b/src/providers/TokensProvider.tsx
@@ -1,4 +1,3 @@
-import { BasicPool, BasicPoolsContext } from "./BasicPoolsProvider"
 import {
   MulticallCall,
   MulticallContract,
@@ -7,11 +6,11 @@ import {
 import React, { ReactElement, useContext, useEffect, useState } from "react"
 import { getMulticallProvider, isSynthAsset } from "../utils"
 
+import { BasicPoolsContext } from "./BasicPoolsProvider"
 import { ChainId } from "../constants"
 import { Contract } from "ethcall"
 import ERC20_ABI from "../constants/abis/erc20.json"
 import { Erc20 } from "./../../types/ethers-contracts/Erc20.d"
-import { Gauge } from "../utils/gauges"
 import { GaugeContext } from "./GaugeProvider"
 import { MinichefContext } from "./MinichefProvider"
 import { useActiveWeb3React } from "../hooks"
@@ -31,20 +30,20 @@ export default function TokensProvider({
   children,
 }: React.PropsWithChildren<unknown>): ReactElement {
   const { chainId, library } = useActiveWeb3React()
-  const pools = useContext(BasicPoolsContext)
+  const basicPools = useContext(BasicPoolsContext)
   const minichefData = useContext(MinichefContext)
   const gauges = useContext(GaugeContext)
   const [tokens, setTokens] = useState<BasicTokens>(null)
   useEffect(() => {
     async function fetchTokens() {
-      if (!chainId || !library || !pools) {
+      if (!chainId || !library || !basicPools) {
         setTokens(null)
         return
       }
       const ethCallProvider = await getMulticallProvider(library, chainId)
       const lpTokens = new Set()
       const targetTokenAddresses = new Set(
-        (Object.values(pools) as BasicPool[])
+        Object.values(basicPools)
           .map((pool) => {
             lpTokens.add(pool.lpToken)
             return [
@@ -63,7 +62,7 @@ export default function TokensProvider({
       }
       if (gauges.gauges) {
         // add gauge tokens
-        ;(Object.values(gauges.gauges) as Gauge[]).forEach((gauge) => {
+        Object.values(gauges.gauges).forEach((gauge) => {
           gauge.rewards.forEach(({ token }) => {
             targetTokenAddresses.add(token)
           })
@@ -81,7 +80,7 @@ export default function TokensProvider({
       setTokens(tokenInfos)
     }
     void fetchTokens()
-  }, [chainId, library, pools, minichefData, gauges.gauges])
+  }, [chainId, library, basicPools, minichefData, gauges.gauges])
   return (
     <TokensContext.Provider value={tokens}>{children}</TokensContext.Provider>
   )

--- a/src/providers/UserStateProvider.tsx
+++ b/src/providers/UserStateProvider.tsx
@@ -1,15 +1,11 @@
 import { BLOCK_TIME, ChainId } from "../constants"
-import { BasicPool, BasicPoolsContext } from "./BasicPoolsProvider"
-import {
-  Gauge,
-  GaugeRewardUserData,
-  getGaugeRewardsUserData,
-} from "../utils/gauges"
+import { GaugeRewardUserData, getGaugeRewardsUserData } from "../utils/gauges"
 import { MinichefUserData, getMinichefRewardsUserData } from "../utils/minichef"
 import { MulticallCall, MulticallContract } from "../types/ethcall"
 import React, { ReactElement, useCallback, useContext, useState } from "react"
 import { batchArray, getMulticallProvider } from "../utils"
 
+import { BasicPoolsContext } from "./BasicPoolsProvider"
 import { BigNumber } from "@ethersproject/bignumber"
 import { Contract } from "ethcall"
 import ERC20_ABI from "../constants/abis/erc20.json"
@@ -56,18 +52,14 @@ export default function UserStateProvider({
       const minichefDataPromise = getMinichefRewardsUserData(
         library,
         chainId,
-        (Object.values(basicPools) as BasicPool[]).map(
-          ({ poolAddress }) => poolAddress,
-        ),
+        Object.values(basicPools).map(({ poolAddress }) => poolAddress),
         account,
       )
       const gaugeRewardsPromise = gauges.gauges
         ? getGaugeRewardsUserData(
             library,
             chainId,
-            (Object.values(gauges.gauges) as Gauge[]).map(
-              ({ address }) => address,
-            ),
+            Object.values(gauges.gauges).map(({ address }) => address),
             account,
           )
         : Promise.resolve(null)

--- a/src/react-app-env.d.ts
+++ b/src/react-app-env.d.ts
@@ -45,4 +45,7 @@ type ObjectKeys<T> = T extends object
 
 interface ObjectConstructor {
   keys<T>(o: T): ObjectKeys<T>
+  values<T>(o: { [s: string]: T } | ArrayLike<T>): Exclude<T, undefined>[]
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  values(o: {}): any[]
 }


### PR DESCRIPTION
key: value mappings should be correctly defined as `{[key: string]: value | undefined}` since `map[anyKey]` is not guaranteed to be defined. 
However, this can be annoying when using `Object.values` since it'll think the value may be undefined, when we know that's not the case. Update the type for `Object.values` to never be undefined (may still be null)