### PR TITLE
Add veSDL data

### DIFF
--- a/src/components/DepositPage.tsx
+++ b/src/components/DepositPage.tsx
@@ -1,5 +1,6 @@
 import {
   ALETH_POOL_NAME,
+  IS_VESDL_LIVE,
   TBTC_METAPOOL_V2_NAME,
   VETH2_POOL_NAME,
   isMetaPool,
@@ -149,8 +150,6 @@ const DepositPage = (props: Props): ReactElement => {
     }
   }
 
-  const veSDLFeatureReady = false // TODO: delete after release.
-
   return (
     <Container maxWidth={isLgDown ? "sm" : "lg"} sx={{ pt: 5, pb: 10 }}>
       {poolData?.name === VETH2_POOL_NAME &&
@@ -176,7 +175,7 @@ const DepositPage = (props: Props): ReactElement => {
           </Typography>
         </Alert>
       )}
-      {veSDLFeatureReady && amountStakedMinichef.gt(Zero) && (
+      {IS_VESDL_LIVE && amountStakedMinichef.gt(Zero) && (
         <Alert severity="error" sx={{ mb: 2 }}>
           <Box display="flex" alignItems="center" justifyContent="space-around">
             <Typography>

--- a/src/components/MyFarm.tsx
+++ b/src/components/MyFarm.tsx
@@ -1,5 +1,5 @@
 import { Box, Button, Paper, Stack, Typography } from "@mui/material"
-import { ChainId, IS_SDL_LIVE } from "../constants"
+import { ChainId, IS_SDL_LIVE, IS_VESDL_LIVE } from "../constants"
 import React, { ReactElement, useCallback, useContext } from "react"
 import { commify, formatBNToString } from "../utils"
 
@@ -75,13 +75,11 @@ export default function MyFarm({
     })
   }, [account, chainId, liquidityGaugeContract, lpTokenContract, poolName])
 
-  const veSDLFeatureReady = false
-
   return isPoolIncentivized && IS_SDL_LIVE ? (
     <Paper sx={{ flex: 1 }}>
       <Stack spacing={2} p={4}>
         <Typography variant="h1">
-          {veSDLFeatureReady ? t("myGaugeFarm") : t("myFarm")}
+          {IS_VESDL_LIVE ? t("myGaugeFarm") : t("myFarm")}
         </Typography>
         <Box display="flex" alignItems="center">
           <Box flex={1}>
@@ -97,7 +95,7 @@ export default function MyFarm({
               fullWidth
               disabled={lpWalletBalance.isZero()}
               onClick={
-                veSDLFeatureReady
+                IS_VESDL_LIVE
                   ? onStakeClick
                   : () => approveAndStake(lpWalletBalance)
               }
@@ -110,7 +108,7 @@ export default function MyFarm({
           <Box flex={1}>
             <Typography>{t("lpStaked")}</Typography>
             <Typography variant="subtitle1">
-              {veSDLFeatureReady
+              {IS_VESDL_LIVE
                 ? formattedLiquidityGaugeLpStakedBalance
                 : formattedLpStakedBalance}
             </Typography>
@@ -121,12 +119,12 @@ export default function MyFarm({
               size="large"
               fullWidth
               disabled={
-                veSDLFeatureReady
+                IS_VESDL_LIVE
                   ? gaugeBalance.isZero()
                   : amountStakedMinichef.isZero()
               }
               onClick={
-                veSDLFeatureReady
+                IS_VESDL_LIVE
                   ? onUnstakeClick
                   : () => unstakeMinichef(amountStakedMinichef)
               }

--- a/src/constants/abis/genericToken.json
+++ b/src/constants/abis/genericToken.json
@@ -1,0 +1,35 @@
+[
+  {
+    "constant": true,
+    "inputs": [
+      { "name": "_owner", "type": "address" },
+      { "name": "_spender", "type": "address" }
+    ],
+    "name": "allowance",
+    "outputs": [{ "name": "", "type": "uint256" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": true,
+    "inputs": [],
+    "name": "name",
+    "outputs": [{ "name": "", "type": "string" }],
+    "payable": false,
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "constant": false,
+    "inputs": [
+      { "name": "_spender", "type": "address" },
+      { "name": "_value", "type": "uint256" }
+    ],
+    "name": "approve",
+    "outputs": [{ "name": "", "type": "bool" }],
+    "payable": false,
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1836,7 +1836,13 @@ export const SYNTH_TRACKING_ID =
 export const IS_VIRTUAL_SWAP_ACTIVE = true
 export const IS_L2_SUPPORTED = true
 export const IS_SDL_LIVE = true
+export const IS_VESDL_LIVE = false
 // FLAGS END
 
 // Regex for readable decimal number
 export const readableDecimalNumberRegex = /^[0-9]*[.,]?[0-9]*$/
+
+// Numbers and durations
+export const BN_1E18 = BigNumber.from(10).pow(18)
+export const BN_DAY_IN_SECONDS = BigNumber.from(24 * 60 * 60)
+export const BN_YEAR_IN_SECONDS = BN_DAY_IN_SECONDS.mul(365)

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -13,7 +13,6 @@ import {
   Token,
   VOTING_ESCROW_CONTRACT_ADDRESS,
 } from "../constants"
-
 import { getContract, getSwapContract } from "../utils"
 import { useContext, useEffect, useMemo, useState } from "react"
 
@@ -46,6 +45,7 @@ import { RetroactiveVesting } from "../../types/ethers-contracts/RetroactiveVest
 import SDL_TOKEN_ABI from "../constants/abis/sdl.json"
 import SYNTHETIX_EXCHANGE_RATE_CONTRACT_ABI from "../constants/abis/synthetixExchangeRate.json"
 import SYNTHETIX_NETWORK_TOKEN_CONTRACT_ABI from "../constants/abis/synthetixNetworkToken.json"
+import { Sdl } from "../../types/ethers-contracts/Sdl"
 import { SwapFlashLoan } from "../../types/ethers-contracts/SwapFlashLoan"
 import { SwapFlashLoanNoWithdrawFee } from "../../types/ethers-contracts/SwapFlashLoanNoWithdrawFee"
 import { SwapGuarded } from "../../types/ethers-contracts/SwapGuarded"
@@ -326,10 +326,10 @@ export function useGaugeControllerContract(): GaugeController | null {
   return useContract(contractAddress, GAUGE_CONTROLLER_ABI) as GaugeController
 }
 
-export const useSdlContract = (): Erc20 => {
+export const useSdlContract = (): Sdl => {
   const { chainId } = useActiveWeb3React()
   const contractAddress = chainId ? SDL_TOKEN_ADDRESSES[chainId] : undefined
-  return useContract(contractAddress, SDL_TOKEN_ABI) as Erc20
+  return useContract(contractAddress, SDL_TOKEN_ABI) as Sdl
 }
 
 export const useVotingEscrowContract = (): VotingEscrow => {

--- a/src/pages/VeSDL/LockedInfo.tsx
+++ b/src/pages/VeSDL/LockedInfo.tsx
@@ -1,32 +1,68 @@
 import { Box, Paper, Typography } from "@mui/material"
-import React from "react"
+import React, { useEffect, useState } from "react"
+import {
+  useSdlContract,
+  useVotingEscrowContract,
+} from "../../hooks/useContract"
+
+import { BigNumber } from "@ethersproject/bignumber"
+import { ChainId } from "../../constants"
+import { formatBNToShortString } from "../../utils"
+import { useActiveWeb3React } from "../../hooks"
 import { useTranslation } from "react-i18next"
 
-type LockedInfoProps = {
-  sdlLocked?: string
-  totalveSdl?: string
-  avgLockTime?: string
-}
-
-export default function LockedInfo({
-  sdlLocked,
-  totalveSdl,
-  avgLockTime,
-}: LockedInfoProps): JSX.Element {
+// TODO add avgLockTime data
+export default function LockedInfo(): JSX.Element {
   const { t } = useTranslation()
+  const { account, chainId, library } = useActiveWeb3React()
+
+  const votingEscrowContract = useVotingEscrowContract()
+  const sdlContract = useSdlContract()
+  const [aggSDLInfo, setAggSDLInfo] = useState<{
+    sdlLocked: BigNumber
+    totalVeSDL: BigNumber
+  } | null>(null)
+
+  useEffect(() => {
+    // TODO move to API to work cross-chain
+    async function fetchSDLInfo() {
+      if (
+        !library ||
+        (chainId !== ChainId.MAINNET && chainId !== ChainId.HARDHAT) ||
+        !account ||
+        !sdlContract ||
+        !votingEscrowContract
+      )
+        return
+      const [totalVeSDL, sdlLocked] = await Promise.all([
+        votingEscrowContract["totalSupply()"](),
+        sdlContract.balanceOf(votingEscrowContract.address),
+      ])
+      setAggSDLInfo({
+        sdlLocked,
+        totalVeSDL,
+      })
+    }
+    void fetchSDLInfo()
+  }, [account, chainId, library, sdlContract, votingEscrowContract])
+
   return (
     <Paper sx={{ display: "flex", p: 2 }}>
       <Box flex={1}>
         <Typography>{t("sdlLocked")}</Typography>
-        <Typography variant="subtitle1">{sdlLocked || "-"}</Typography>
+        <Typography variant="subtitle1">
+          {aggSDLInfo ? formatBNToShortString(aggSDLInfo.sdlLocked, 18) : "-"}
+        </Typography>
       </Box>
       <Box flex={1}>
         <Typography>{t("totalVeSDL")}</Typography>
-        <Typography variant="subtitle1">{totalveSdl || "-"}</Typography>
+        <Typography variant="subtitle1">
+          {aggSDLInfo ? formatBNToShortString(aggSDLInfo.totalVeSDL, 18) : "-"}
+        </Typography>
       </Box>
       <Box flex={1}>
         <Typography>{t("avgLockTime")}</Typography>
-        <Typography variant="subtitle1">{avgLockTime || "-"}</Typography>
+        <Typography variant="subtitle1">{"-"}</Typography>
       </Box>
     </Paper>
   )

--- a/src/utils/checkAndApproveTokenForTrade.ts
+++ b/src/utils/checkAndApproveTokenForTrade.ts
@@ -1,8 +1,6 @@
 import { BigNumber } from "@ethersproject/bignumber"
 import { ChainId } from "../constants"
-import { Erc20 } from "../../types/ethers-contracts/Erc20"
-import { LpTokenGuarded } from "../../types/ethers-contracts/LpTokenGuarded"
-import { LpTokenUnguarded } from "../../types/ethers-contracts/LpTokenUnguarded"
+import { GenericToken } from "../../types/ethers-contracts/GenericToken"
 import { MaxUint256 } from "@ethersproject/constants"
 import { Zero } from "@ethersproject/constants"
 import { enqueuePromiseToast } from "../components/Toastify"
@@ -20,7 +18,7 @@ import { enqueuePromiseToast } from "../components/Toastify"
  * @return {Promise<void>}
  */
 export default async function checkAndApproveTokenForTrade(
-  srcTokenContract: Erc20 | LpTokenGuarded | LpTokenUnguarded,
+  srcTokenContract: GenericToken,
   spenderAddress: string,
   ownerAddress: string,
   spendingValue: BigNumber, // max is MaxUint256


### PR DESCRIPTION
Add veSDL data to gauge page

Cleanup:
- move `veSDLFeatureReady` to global constant
- introduce `GenericToken` abi for basic tasks like approvals
- change `useSdlContract` type to `Sdl`

<img width="505" alt="Screen Shot 2022-05-26 at 8 34 15 PM" src="https://user-images.githubusercontent.com/7607886/170623958-0571b568-8c04-4fe3-adf3-bc430cccb96b.png">