### PR TITLE
Fix the withdraw issue

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1338,7 +1338,7 @@ export const POOLS_MAP: PoolsMap = {
     isSynthetic: false,
     type: PoolTypes.USD,
     route: "frax-3pool",
-    rewardPids: buildPids({}),
+    rewardPids: buildPids({ [ChainId.MAINNET]: 11 }),
   },
   [STABLECOIN_POOL_NAME]: {
     name: STABLECOIN_POOL_NAME,
@@ -1637,6 +1637,7 @@ const minichefPids: Partial<Record<ChainId, { [pool: string]: number }>> = {
     [SUSD_META_SWAP_V3_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 9,
     [WCUSD_META_SWAP_V3_DEPOSIT_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 10,
     [WCUSD_META_SWAP_V3_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 10,
+    [FRAX_3_POOL_SWAP_ADDRESSES[ChainId.MAINNET].toLowerCase()]: 11,
   },
   [ChainId.HARDHAT]: {
     [ALETH_SWAP_ADDRESSES[ChainId.HARDHAT].toLowerCase()]: 1,

--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -45,6 +45,7 @@ function Withdraw({ poolName }: Props): ReactElement {
   const withdrawTokens = poolData.isMetaSwap
     ? poolData.underlyingTokens
     : poolData.tokens
+
   const tokenInputSum = useMemo(() => {
     return withdrawTokens.reduce(
       (sum, { address }) =>
@@ -173,7 +174,7 @@ function Withdraw({ poolName }: Props): ReactElement {
         ),
         symbol,
       })
-      if (tokenPricesUSD != null) {
+      if (tokenPricesUSD && tokenPricesUSD[symbol]) {
         reviewWithdrawData.rates.push({
           name,
           value: formatUnits(

--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -174,6 +174,7 @@ function Withdraw({ poolName }: Props): ReactElement {
         ),
         symbol,
       })
+      console.log("token price usd ==>", tokenPricesUSD)
       if (tokenPricesUSD && tokenPricesUSD[symbol]) {
         reviewWithdrawData.rates.push({
           name,


### PR DESCRIPTION
## What does this PR do?

Preventing the white page when withdraw

## description.
To withdraw token, when user input the percent on the withdraw page, it appears white screen.
Because LP token don't have price(it is having undefined), and it make invalide input on `commify` function. That was the reason of blank screen.
