### PR TITLE
Fix Withdraw issue

### DIFF
--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -173,14 +173,14 @@ function Withdraw({ poolName }: Props): ReactElement {
         ),
         symbol,
       })
-      if (tokenPricesUSD != null) {
+      if (tokenPricesUSD && tokenPricesUSD[symbol]) {
         reviewWithdrawData.rates.push({
           name,
           value: formatUnits(
             withdrawFormState.tokenInputs[address]?.valueSafe || "0",
             decimals,
           ),
-          rate: commify(tokenPricesUSD[symbol]?.toFixed(2)), // TODO
+          rate: commify(tokenPricesUSD[symbol].toFixed(2)), // TODO
         })
       }
     }


### PR DESCRIPTION
## What does this PR do?

Preventing the white page when withdraw

## Description.
To withdraw token, when user input the percent on the withdraw page, it appears white screen.
Because LP token don't have price(it is having undefined), and it make invalide input on `commify` function. That was the reason of blank screen.
