### PR TITLE
Key gauges by lpToken address

### DIFF
--- a/src/components/DepositPage.tsx
+++ b/src/components/DepositPage.tsx
@@ -95,7 +95,7 @@ const DepositPage = (props: Props): ReactElement => {
   const theme = useTheme()
   const isLgDown = useMediaQuery(theme.breakpoints.down("lg"))
   const { gauges } = useContext(GaugeContext)
-  const gaugeAddr = gauges?.[poolData?.poolAddress ?? ""]?.address ?? ""
+  const gaugeAddr = gauges?.[poolData?.lpToken ?? ""]?.address ?? ""
   const gaugesAreActive = areGaugesActive(chainId)
 
   useEffect(() => {

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -10,6 +10,7 @@ import { useContext, useEffect, useState } from "react"
 import { AppState } from "../state"
 import { BasicPoolsContext } from "./../providers/BasicPoolsProvider"
 import { BigNumber } from "@ethersproject/bignumber"
+import { GaugeContext } from "./../providers/GaugeProvider"
 import { MinichefContext } from "../providers/MinichefProvider"
 import { PoolTypes } from "./../constants/index"
 import { UserStateContext } from "./../providers/UserStateProvider"
@@ -118,6 +119,7 @@ export default function usePoolData(name?: string): PoolDataHookReturnType {
   const tokens = useContext(TokensContext)
   const userState = useContext(UserStateContext)
   const minichefData = useContext(MinichefContext)
+  const { gauges } = useContext(GaugeContext)
   const gaugeAprs = useContext(AprsContext)
   const { tokenPricesUSD, swapStats } = useSelector(
     (state: AppState) => state.application,
@@ -148,7 +150,7 @@ export default function usePoolData(name?: string): PoolDataHookReturnType {
       }
       try {
         const poolMinichefData = minichefData?.pools?.[basicPool.poolAddress]
-        // const poolGaugeData = gauges?.[basicPool.poolAddress]
+        const poolGaugeData = gauges?.[basicPool.lpToken]
         const expandedPoolTokens = basicPool.tokens.map(
           (tokenAddr) => tokens[tokenAddr],
         ) as BasicToken[]
@@ -188,7 +190,7 @@ export default function usePoolData(name?: string): PoolDataHookReturnType {
             tokenPricesUSD,
             priceDataForPool.lpTokenPriceUSD,
           )
-        const poolGaugeAprs = gaugeAprs?.[basicPool.poolAddress]
+        const poolGaugeAprs = gaugeAprs?.[poolGaugeData?.address ?? ""]
 
         // User share data
         const userWalletLpTokenBalance =
@@ -335,6 +337,7 @@ export default function usePoolData(name?: string): PoolDataHookReturnType {
     userState?.tokenBalances,
     userState?.gaugeRewards,
     gaugeAprs,
+    gauges,
   ])
 
   return [poolData, userShare, setPoolName]

--- a/src/pages/VeSDL/GaugeVote.tsx
+++ b/src/pages/VeSDL/GaugeVote.tsx
@@ -1,7 +1,6 @@
 import {
   Box,
   Button,
-  CircularProgress,
   Link,
   Paper,
   Table,
@@ -12,20 +11,19 @@ import {
   TableRow,
   Typography,
 } from "@mui/material"
-import React, { useContext } from "react"
 import {
   SNAPSHOT_STATE,
   VoteEscrowSnapshots,
 } from "../../state/voteEscrowSnapshots"
+
 import { AppState } from "../../state"
-import { GaugeContext } from "../../providers/GaugeProvider"
 import GaugeWeight from "../../components/GaugeWeight"
+import React from "react"
 import { generateSnapshotVoteLink } from "../../utils"
 import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
 
 export default function GaugeVote(): JSX.Element {
-  const gaugeData = useContext(GaugeContext)
   const { snapshots }: VoteEscrowSnapshots = useSelector(
     (state: AppState) => state.voteEscrowSnapshots,
   )
@@ -37,18 +35,7 @@ export default function GaugeVote(): JSX.Element {
         {t("gaugeVote")}
       </Typography>
       <Box height="428px">
-        {!gaugeData ? (
-          <Box
-            display="flex"
-            height="100%"
-            alignItems="center"
-            justifyContent="center"
-          >
-            <CircularProgress color="secondary" />
-          </Box>
-        ) : (
-          <GaugeWeight gauges={gaugeData.gauges} />
-        )}
+        <GaugeWeight />
       </Box>
       <TableContainer>
         <Table size="small">

--- a/src/pages/VeSDL/VeTokenCalculator.tsx
+++ b/src/pages/VeSDL/VeTokenCalculator.tsx
@@ -8,6 +8,7 @@ import {
 } from "@mui/material"
 import React, { useContext, useEffect, useState } from "react"
 import { calculateBoost, formatBNToString, isNumberOrEmpty } from "../../utils"
+
 import ArrowDownIcon from "@mui/icons-material/KeyboardArrowDown"
 import { BasicPoolsContext } from "../../providers/BasicPoolsProvider"
 import { BigNumber } from "@ethersproject/bignumber"
@@ -45,8 +46,8 @@ export default function VeTokenCalculator({
 
   const pool = basicPools && basicPools[poolNameValue]
   const gauge =
-    !!pool?.poolAddress && gaugeData.gauges
-      ? gaugeData.gauges[pool.poolAddress]
+    !!pool?.lpToken && gaugeData.gauges
+      ? gaugeData.gauges[pool.lpToken]
       : undefined
 
   const userLPAmountBN = parseEther(userLPAmountInput || "0")

--- a/src/providers/AprsProvider.tsx
+++ b/src/providers/AprsProvider.tsx
@@ -1,5 +1,9 @@
 import { BN_DAY_IN_SECONDS, BN_YEAR_IN_SECONDS } from "./../constants/index"
-import { BasicToken, TokensContext } from "../providers/TokensProvider"
+import {
+  BasicToken,
+  BasicTokens,
+  TokensContext,
+} from "../providers/TokensProvider"
 import React, { ReactElement, useContext } from "react"
 import { getPriceDataForPool, shiftBNDecimals } from "../utils"
 
@@ -7,6 +11,8 @@ import { AppState } from "../state"
 import { BasicPoolsContext } from "./../providers/BasicPoolsProvider"
 import { BigNumber } from "ethers"
 import { GaugeContext } from "../providers/GaugeProvider"
+import { GaugeReward } from "../utils/gauges"
+import { Zero } from "@ethersproject/constants"
 import { parseUnits } from "@ethersproject/units"
 import { useSelector } from "react-redux"
 
@@ -26,7 +32,7 @@ type AprReward = {
 }
 export type GaugeApr = AmountReward | AprReward
 type Aprs = Partial<{
-  [poolAddress: string]: GaugeApr[]
+  [gaugeAddress: string]: GaugeApr[]
 }>
 export const AprsContext = React.createContext<Aprs | null>(null)
 
@@ -45,52 +51,70 @@ function useGaugeAprs() {
 
   if (!basicPools || !tokens || !tokenPricesUSD) return null
 
-  return Object.values(basicPools).reduce((acc, basicPool) => {
-    const gauge = gauges[basicPool.poolAddress]
-    if (!(gauge && gauge?.workingSupply)) return acc
+  return Object.values(gauges).reduce((acc, gauge) => {
     const { rewards, workingSupply } = gauge
-    const { assetPrice } = getPriceDataForPool(
+    const basicPool = basicPools?.[gauge.poolAddress ?? ""]
+    let gaugeAssetPrice = Zero
+    if (basicPool) {
+      const { assetPrice } = getPriceDataForPool(
+        tokens,
+        basicPool,
+        tokenPricesUSD,
+      )
+      gaugeAssetPrice = assetPrice
+    }
+    const rewardAprs = buildRewards(
+      rewards,
       tokens,
-      basicPool,
       tokenPricesUSD,
-    )
-    const rewardAprs = rewards.map(
-      ({ tokenAddress, rate: rewardPerSecond }) => {
-        const rewardToken = tokens[tokenAddress]
-        const rewardPrice = tokenPricesUSD[rewardToken?.symbol || ""] || 0
-
-        if (rewardPrice === 0) {
-          const maxRewardPerDay = rewardPerSecond.mul(BN_DAY_IN_SECONDS)
-          return {
-            rewardToken,
-            amountPerDay: {
-              min: maxRewardPerDay.mul(4).div(10),
-              max: maxRewardPerDay,
-            },
-          }
-        }
-        // @dev see "Math" section of readme
-        const amountStakedUSD = workingSupply.mul(assetPrice) // 1e18 * 1e18 = 1e36
-        const rewardPerYear = rewardPerSecond.mul(BN_YEAR_IN_SECONDS) // 1e18
-        const rewardPerYearUSD = rewardPerYear.mul(
-          parseUnits(rewardPrice.toFixed(3), 3),
-        ) // 1e18 * 1e3 = 1e21
-        const rewardApr = shiftBNDecimals(rewardPerYearUSD, 33).div(
-          amountStakedUSD,
-        ) // (1e21 * 1e33 = 1e54) / 1e36 = 1e18
-
-        return {
-          rewardToken,
-          apr: {
-            min: rewardApr.mul(4).div(10),
-            max: rewardApr,
-          },
-        }
-      },
+      workingSupply || Zero,
+      gaugeAssetPrice,
     )
     return {
       ...acc,
-      [basicPool.poolAddress]: rewardAprs,
+      [gauge.address]: rewardAprs,
     }
   }, {}) as Aprs
+}
+
+/**
+ * Builds the APRs for a gauge, given generic pool data (supply and asset price)
+ */
+function buildRewards(
+  gaugeRewards: GaugeReward[],
+  tokens: NonNullable<BasicTokens>,
+  tokenPricesUSD: Partial<{ [symbol: string]: number }>,
+  poolSupply: BigNumber,
+  poolAssetPrice: BigNumber,
+): GaugeApr[] {
+  return gaugeRewards.map(({ tokenAddress, rate: rewardPerSecond }) => {
+    const rewardToken = tokens[tokenAddress]
+    const rewardPrice = tokenPricesUSD[rewardToken?.symbol || ""] || 0
+    const amountStakedUSD = poolSupply.mul(poolAssetPrice) // 1e18 * 1e18 = 1e36
+
+    if (rewardPrice === 0 || amountStakedUSD.isZero()) {
+      const maxRewardPerDay = rewardPerSecond.mul(BN_DAY_IN_SECONDS)
+      return {
+        rewardToken,
+        amountPerDay: {
+          min: maxRewardPerDay.mul(4).div(10),
+          max: maxRewardPerDay,
+        },
+      } as AmountReward
+    }
+    // @dev see "Math" section of readme
+    const rewardPerYear = rewardPerSecond.mul(BN_YEAR_IN_SECONDS) // 1e18
+    const rewardPerYearUSD = rewardPerYear.mul(
+      parseUnits(rewardPrice.toFixed(3), 3),
+    ) // 1e18 * 1e3 = 1e21
+    const rewardApr = shiftBNDecimals(rewardPerYearUSD, 33).div(amountStakedUSD) // (1e21 * 1e33 = 1e54) / 1e36 = 1e18
+
+    return {
+      rewardToken,
+      apr: {
+        min: rewardApr.mul(4).div(10),
+        max: rewardApr,
+      },
+    } as AprReward
+  })
 }

--- a/src/providers/TokensProvider.tsx
+++ b/src/providers/TokensProvider.tsx
@@ -39,7 +39,7 @@ export default function TokensProvider({
   const { chainId, library } = useActiveWeb3React()
   const basicPools = useContext(BasicPoolsContext)
   const minichefData = useContext(MinichefContext)
-  const gauges = useContext(GaugeContext)
+  const { gauges } = useContext(GaugeContext)
   const [tokens, setTokens] = useState<BasicTokens>(null)
   useEffect(() => {
     async function fetchTokens() {
@@ -76,9 +76,9 @@ export default function TokensProvider({
           targetTokenAddresses.add(address)
         })
       }
-      if (gauges.gauges) {
+      if (gauges) {
         // add gauge tokens
-        Object.values(gauges.gauges).forEach((gauge) => {
+        Object.values(gauges).forEach((gauge) => {
           gauge.rewards.forEach(({ tokenAddress }) => {
             targetTokenAddresses.add(tokenAddress)
           })
@@ -86,11 +86,15 @@ export default function TokensProvider({
       }
       if (SDL_WETH_SUSHI_LP_CONTRACT_ADDRESSES[chainId] && gaugesAreActive) {
         // add sushi token
-        targetTokenAddresses.add(SDL_WETH_SUSHI_LP_CONTRACT_ADDRESSES[chainId])
+        targetTokenAddresses.add(
+          SDL_WETH_SUSHI_LP_CONTRACT_ADDRESSES[chainId].toLowerCase(),
+        )
       }
       if (VOTING_ESCROW_CONTRACT_ADDRESS[chainId] && gaugesAreActive) {
         // add voting escrow token
-        targetTokenAddresses.add(VOTING_ESCROW_CONTRACT_ADDRESS[chainId])
+        targetTokenAddresses.add(
+          VOTING_ESCROW_CONTRACT_ADDRESS[chainId].toLowerCase(),
+        )
       }
       const tokenInfos = await getTokenInfos(
         ethCallProvider,
@@ -106,7 +110,7 @@ export default function TokensProvider({
       setTokens(tokenInfos)
     }
     void fetchTokens()
-  }, [chainId, library, basicPools, minichefData, gauges.gauges])
+  }, [chainId, library, basicPools, minichefData, gauges])
   return (
     <TokensContext.Provider value={tokens}>{children}</TokensContext.Provider>
   )

--- a/src/providers/UserStateProvider.tsx
+++ b/src/providers/UserStateProvider.tsx
@@ -38,7 +38,7 @@ export default function UserStateProvider({
   const basicPools = useContext(BasicPoolsContext)
   const tokens = useContext(TokensContext)
 
-  const gauges = useContext(GaugeContext)
+  const { gauges } = useContext(GaugeContext)
   const feeDistributorContract = useFeeDistributor()
   const [userState, setUserState] = useState<UserState>(null)
   const fetchState = useCallback(() => {
@@ -59,12 +59,12 @@ export default function UserStateProvider({
         Object.values(basicPools).map(({ poolAddress }) => poolAddress),
         account,
       )
-      const gaugeRewardsPromise = gauges.gauges
+      const gaugeRewardsPromise = gauges
         ? getGaugeRewardsUserData(
             library,
             chainId,
-            Object.values(gauges.gauges).map(({ address }) => address),
-            Object.values(gauges.gauges).map(({ rewards }) =>
+            Object.values(gauges).map(({ address }) => address),
+            Object.values(gauges).map(({ rewards }) =>
               rewards.map(({ tokenAddress }) => tokenAddress),
             ),
             account,
@@ -101,7 +101,7 @@ export default function UserStateProvider({
     account,
     basicPools,
     tokens,
-    gauges.gauges,
+    gauges,
     feeDistributorContract,
   ])
   usePoller(fetchState, BLOCK_TIME * 2, [fetchState])

--- a/src/utils/updateSdlWethSushiInfo.ts
+++ b/src/utils/updateSdlWethSushiInfo.ts
@@ -1,4 +1,6 @@
 import { AppDispatch } from "../state"
+import { BN_1E18 } from "./../constants/index"
+import { BigNumber } from "ethers"
 import { ChainId } from "../constants"
 import { SushiPool } from "./../../types/ethers-contracts/SushiPool.d"
 import { areGaugesActive } from "./gauges"
@@ -26,7 +28,18 @@ export default function fetchSdlWethSushiPoolInfo(
       )
     })
     .catch((e) => {
-      console.error(e)
-      dispatch(updateSdlWethSushiPool(null))
+      if (chainId === ChainId.HARDHAT) {
+        dispatch(
+          updateSdlWethSushiPool({
+            totalSupply: BigNumber.from(10).mul(BN_1E18),
+            wethReserve: BigNumber.from(10).mul(BN_1E18),
+            sdlReserve: BigNumber.from(55000).mul(BN_1E18),
+          }),
+        )
+        return
+      } else {
+        console.error(e)
+        dispatch(updateSdlWethSushiPool(null))
+      }
     })
 }


### PR DESCRIPTION
Move gauges from being keyed on poolAddress to lpTokenAddress, since our gauges now also support the sdl/weth sushi lp token.

gaugeAprs are now keyed on gaugeAddress instead of poolAddress so that APRs for all gauges are calculated. 

TODO - we have the assetPrice for pools, but we should figure out how to get that for the sushi pair 