### PR TITLE
Add SDL icon & price to header

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -1,3 +1,5 @@
+//@ts-nocheck
+// @eslint-ignore
 import {
   AppBar,
   Box,
@@ -13,6 +15,7 @@ import { IS_SDL_LIVE, IS_VESDL_LIVE } from "../constants"
 import { NavLink, NavLinkProps, useLocation } from "react-router-dom"
 import React, { ReactElement, useContext, useState } from "react"
 
+import { AppState } from "../state"
 import { IS_DEVELOPMENT } from "../utils/environment"
 import { MoreVert } from "@mui/icons-material"
 import NetworkDisplay from "./NetworkDisplay"
@@ -20,8 +23,10 @@ import { RewardsBalancesContext } from "../providers/RewardsBalancesProvider"
 import { ReactComponent as SaddleLogo } from "../assets/icons/logo.svg"
 import SiteSettingsMenu from "./SiteSettingsMenu"
 import TokenClaimDialog from "./TokenClaimDialog"
+import { TokenPricesUSD } from "../state/application"
 import Web3Status from "./Web3Status"
 import { formatBNToShortString } from "../utils"
+import { useSelector } from "react-redux"
 import { useTranslation } from "react-i18next"
 
 type ActiveTabType = "" | "pools" | "risk" | "vesdl" | "farm"
@@ -44,7 +49,7 @@ function TopMenu(): ReactElement {
   const theme = useTheme()
   const { pathname } = useLocation()
   const activeTab = pathname.split("/")[1] as ActiveTabType
-
+  const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
   const handleSettingMenu = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
@@ -119,6 +124,7 @@ function TopMenu(): ReactElement {
             justifyContent={{ xs: "center", lg: "flex-end" }}
             alignItems="center"
           >
+            <SDLPrice tokenPricesUSD={tokenPricesUSD} />
             <RewardsButton setCurrentModal={setCurrentModal} />
             <Web3Status />
             <NetworkDisplay onClick={handleSettingMenu} />
@@ -174,6 +180,30 @@ function RewardsButton({
       {formattedTotal}
     </Button>
   ) : null
+}
+
+function SDLPrice({ tokenPricesUSD }: TokenPricesUSD): ReactElement | null {
+  const isSDLPriceAvailable =
+    tokenPricesUSD !== undefined && tokenPricesUSD["SDL"] !== undefined
+  if (isSDLPriceAvailable) {
+    const sdlPrice = tokenPricesUSD["SDL"] as number
+    const SUSHI_WETH_SDL_POOL_URL =
+      "https://app.sushi.com/analytics/pools/0x0c6f06b32e6ae0c110861b8607e67da594781961?chainId=1"
+    return (
+      <Button
+        variant="contained"
+        color="info"
+        data-testid="sdlPriceButton"
+        href={SUSHI_WETH_SDL_POOL_URL}
+        target="_blank"
+        startIcon={<SaddleLogo width={20} height={20} />}
+        style={{ minWidth: 250 }}
+      >
+        {`SDL Price: ${sdlPrice}`}
+      </Button>
+    )
+  }
+  return null
 }
 
 export default TopMenu

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -47,7 +47,7 @@ function TopMenu(): ReactElement {
   const { pathname } = useLocation()
   const activeTab = pathname.split("/")[1] as ActiveTabType
   const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
-  const sdlPrice = tokenPricesUSD?.[SDL_TOKEN.geckoId]
+  const sdlPrice = tokenPricesUSD?.[SDL_TOKEN.symbol]
   const handleSettingMenu = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
@@ -197,9 +197,9 @@ function SDLPrice({ sdlPrice }: SDLPriceProps): ReactElement | null {
       href={SUSHI_WETH_SDL_POOL_URL}
       target="_blank"
       startIcon={<SaddleLogo width={20} height={20} />}
-      style={{ minWidth: 250 }}
+      style={{ minWidth: 100 }}
     >
-      {`SDL Price: ${sdlPrice}`}
+      {`$${sdlPrice.toFixed(2)}`}
     </Button>
   )
 }

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -185,25 +185,23 @@ interface SDLPriceProps {
 }
 
 function SDLPrice({ sdlPrice }: SDLPriceProps): ReactElement | null {
-  if (sdlPrice !== undefined) {
-    const SUSHI_WETH_SDL_POOL_URL =
-      "https://app.sushi.com/analytics/pools/0x0c6f06b32e6ae0c110861b8607e67da594781961?chainId=1"
-    return (
-      <Button
-        variant="contained"
-        color="info"
-        data-testid="sdlPriceButton"
-        href={SUSHI_WETH_SDL_POOL_URL}
-        target="_blank"
-        startIcon={<SaddleLogo width={20} height={20} />}
-        style={{ minWidth: 250 }}
-      >
-        {`SDL Price: ${sdlPrice}`}
-      </Button>
-    )
-  }
+  if (sdlPrice === undefined) return null
 
-  return null
+  const SUSHI_WETH_SDL_POOL_URL =
+    "https://app.sushi.com/analytics/pools/0x0c6f06b32e6ae0c110861b8607e67da594781961?chainId=1"
+  return (
+    <Button
+      variant="contained"
+      color="info"
+      data-testid="sdlPriceButton"
+      href={SUSHI_WETH_SDL_POOL_URL}
+      target="_blank"
+      startIcon={<SaddleLogo width={20} height={20} />}
+      style={{ minWidth: 250 }}
+    >
+      {`SDL Price: ${sdlPrice}`}
+    </Button>
+  )
 }
 
 export default TopMenu

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -1,5 +1,3 @@
-//@ts-nocheck
-// @eslint-ignore
 import {
   AppBar,
   Box,
@@ -11,7 +9,7 @@ import {
   styled,
   useTheme,
 } from "@mui/material"
-import { IS_SDL_LIVE, IS_VESDL_LIVE } from "../constants"
+import { IS_SDL_LIVE, IS_VESDL_LIVE, SDL_TOKEN } from "../constants"
 import { NavLink, NavLinkProps, useLocation } from "react-router-dom"
 import React, { ReactElement, useContext, useState } from "react"
 
@@ -23,7 +21,6 @@ import { RewardsBalancesContext } from "../providers/RewardsBalancesProvider"
 import { ReactComponent as SaddleLogo } from "../assets/icons/logo.svg"
 import SiteSettingsMenu from "./SiteSettingsMenu"
 import TokenClaimDialog from "./TokenClaimDialog"
-import { TokenPricesUSD } from "../state/application"
 import Web3Status from "./Web3Status"
 import { formatBNToShortString } from "../utils"
 import { useSelector } from "react-redux"
@@ -50,6 +47,7 @@ function TopMenu(): ReactElement {
   const { pathname } = useLocation()
   const activeTab = pathname.split("/")[1] as ActiveTabType
   const { tokenPricesUSD } = useSelector((state: AppState) => state.application)
+  const sdlPrice = tokenPricesUSD?.[SDL_TOKEN.geckoId]
   const handleSettingMenu = (
     event: React.MouseEvent<HTMLButtonElement, MouseEvent>,
   ) => {
@@ -124,7 +122,7 @@ function TopMenu(): ReactElement {
             justifyContent={{ xs: "center", lg: "flex-end" }}
             alignItems="center"
           >
-            <SDLPrice tokenPricesUSD={tokenPricesUSD} />
+            <SDLPrice sdlPrice={sdlPrice} />
             <RewardsButton setCurrentModal={setCurrentModal} />
             <Web3Status />
             <NetworkDisplay onClick={handleSettingMenu} />
@@ -182,11 +180,12 @@ function RewardsButton({
   ) : null
 }
 
-function SDLPrice({ tokenPricesUSD }: TokenPricesUSD): ReactElement | null {
-  const isSDLPriceAvailable =
-    tokenPricesUSD !== undefined && tokenPricesUSD["SDL"] !== undefined
-  if (isSDLPriceAvailable) {
-    const sdlPrice = tokenPricesUSD["SDL"] as number
+interface SDLPriceProps {
+  sdlPrice: number | undefined
+}
+
+function SDLPrice({ sdlPrice }: SDLPriceProps): ReactElement | null {
+  if (sdlPrice !== undefined) {
     const SUSHI_WETH_SDL_POOL_URL =
       "https://app.sushi.com/analytics/pools/0x0c6f06b32e6ae0c110861b8607e67da594781961?chainId=1"
     return (
@@ -203,6 +202,7 @@ function SDLPrice({ tokenPricesUSD }: TokenPricesUSD): ReactElement | null {
       </Button>
     )
   }
+
   return null
 }
 

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -594,7 +594,7 @@ export const SDL_TOKEN = new Token(
   SDL_TOKEN_ADDRESSES,
   18,
   "SDL",
-  "saddle-dao", // TBD
+  "saddle-finance", // Updated per CoinGecko
   "Saddle DAO",
   false,
   false,

--- a/src/utils/updateTokenPrices.ts
+++ b/src/utils/updateTokenPrices.ts
@@ -6,6 +6,7 @@ import {
 import {
   ChainId,
   PoolTypes,
+  SDL_TOKEN,
   SPA,
   TOKENS_MAP,
   VETH2_SWAP_ADDRESSES,
@@ -41,6 +42,7 @@ const otherTokens = {
   SGT: "sharedstake-governance-token",
   ALCX: "alchemix",
   T: "threshold-network-token",
+  [SDL_TOKEN.symbol]: SDL_TOKEN.geckoId,
   [SPA.symbol]: SPA.geckoId,
 }
 


### PR DESCRIPTION
***Description***: This is to add a button at the top Menu nav bar to include a SDL price tracker. SDL price information will render once CoinGecko starts to return a value for the SDL token. This work also include updating the geckoId of SDL token from `saddle-dao` to `saddle-finance`
#1103 
![image](https://user-images.githubusercontent.com/24193788/174915560-69b86e89-d28b-4e77-81d6-b7067d0fdcba.png)