### PR TITLE
feat: get explorer link by chainid

### DIFF
--- a/src/components/AccountDetails.tsx
+++ b/src/components/AccountDetails.tsx
@@ -19,7 +19,7 @@ import Transactions from "./Transactions"
 import { UserStateContext } from "../providers/UserStateProvider"
 import { Zero } from "@ethersproject/constants"
 import { find } from "lodash"
-import { getEtherscanLink } from "../utils/getEtherscanLink"
+import { getMultichainScanLink } from "../utils/getEtherscanLink"
 import { shortenAddress } from "../utils/shortenAddress"
 import { useActiveWeb3React } from "../hooks"
 import { useTheme } from "@mui/material/styles"
@@ -75,9 +75,9 @@ export default function AccountDetail({ openOptions }: Props): ReactElement {
             <Typography variant="subtitle1">
               {udName || (account && shortenAddress(account))}
             </Typography>
-            {account && (
+            {chainId && account && (
               <Link
-                href={getEtherscanLink(account, "address")}
+                href={getMultichainScanLink(chainId, account, "address")}
                 target="_blank"
                 rel="noreferrer"
               >

--- a/src/components/Transactions.tsx
+++ b/src/components/Transactions.tsx
@@ -19,8 +19,8 @@ import React, {
 } from "react"
 
 import LinkIcon from "@mui/icons-material/Launch"
-import { getEtherscanLink } from "../utils/getEtherscanLink"
 import { getFormattedShortTime } from "../utils/dateTime"
+import { getMultichainScanLink } from "../utils/getEtherscanLink"
 import { useActiveWeb3React } from "../hooks"
 import { useTranslation } from "react-i18next"
 
@@ -211,12 +211,12 @@ export default function Transactions(): ReactElement {
         </Button>
       </Box>
       <List>
-        {transactionList.length !== 0 ? (
+        {chainId && transactionList.length !== 0 ? (
           transactionList.map((txn, index) => (
             <ListItem key={index} disableGutters>
               <Typography marginRight={1}>{txn.object}</Typography>
               <Link
-                href={getEtherscanLink(txn.transaction, "tx")}
+                href={getMultichainScanLink(chainId, txn.transaction, "tx")}
                 target="_blank"
                 rel="noreferrer"
                 sx={{ lineHeight: 0 }}


### PR DESCRIPTION
currently when a user wants to check transactions records only etherscan is avaible, although a user may be on fantom chain for example the link redirects to ehterscan. so the solution here is to utilize the getMultiChainScanLink function and render the links on front end by chainId
Before Screen shot:
![before-screenshot](https://user-images.githubusercontent.com/34605113/174951466-8d3305bb-71cc-4cf7-8654-efab12886439.png)

After Screenshot:
![after-screenshot](https://user-images.githubusercontent.com/34605113/174951516-9c154072-d5af-44ce-856c-12057abb20b4.png)

