### PR TITLE
better logging, hide empty lp

### DIFF
--- a/src/pages/Farm/ClaimRewardsDlg.tsx
+++ b/src/pages/Farm/ClaimRewardsDlg.tsx
@@ -67,7 +67,6 @@ export default function ClaimRewardsDlg({
           </Typography>
           <Typography>Stake your LP token and collect incentives.</Typography>
           <Box>
-            <Typography>LP Staked:</Typography>
             <Typography mt={2}>Rewards:</Typography>
             <UserRewards userGaugeRewards={userGauge?.userGaugeRewards} />
           </Box>

--- a/src/pages/Farm/ClaimRewardsDlg.tsx
+++ b/src/pages/Farm/ClaimRewardsDlg.tsx
@@ -37,7 +37,10 @@ export default function ClaimRewardsDlg({
   const dispatch = useDispatch()
 
   const onClickClaim = useCallback(async () => {
-    if (!chainId) return
+    if (!chainId) {
+      enqueueToast("error", "Unable to claim reward")
+      return
+    }
     try {
       const txns = await userGauge?.claim()
 

--- a/src/pages/Farm/StakeDialog.tsx
+++ b/src/pages/Farm/StakeDialog.tsx
@@ -9,7 +9,12 @@ import {
 } from "@mui/material"
 import React, { useCallback, useState } from "react"
 import { TRANSACTION_TYPES, readableDecimalNumberRegex } from "../../constants"
-import { commify, formatBNToString, getContract } from "../../utils"
+import {
+  commify,
+  formatBNToString,
+  getContract,
+  missingKeys,
+} from "../../utils"
 import { enqueuePromiseToast, enqueueToast } from "../../components/Toastify"
 import { formatUnits, parseUnits } from "ethers/lib/utils"
 import { useDispatch, useSelector } from "react-redux"
@@ -50,8 +55,18 @@ export default function StakeDialog({
 
   const onClickStake = useCallback(async () => {
     try {
-      if (!userGauge || !chainId || !gaugeAddress || !account || !library)
+      if (!userGauge || !chainId || !gaugeAddress || !account || !library) {
+        console.error(
+          `Could not stake: ${missingKeys({
+            userGauge,
+            chainId,
+            gaugeAddress,
+            account,
+            library,
+          }).join(", ")} missing`,
+        )
         return
+      }
       const inputBN = parseUnits(amountInput)
       const lpTokenContract = getContract(
         userGauge.lpToken.address,
@@ -101,7 +116,15 @@ export default function StakeDialog({
 
   const onClickUnstake = useCallback(async () => {
     try {
-      if (!userGauge || !chainId) return
+      if (!userGauge || !chainId) {
+        console.error(
+          `Could not unstake: ${missingKeys({
+            userGauge,
+            chainId,
+          }).join(", ")} missing`,
+        )
+        return
+      }
       const inputBN = parseUnits(amountInput)
       const txn = await userGauge?.unstake(inputBN)
       await enqueuePromiseToast(chainId, txn.wait(), "unstake", {
@@ -130,6 +153,7 @@ export default function StakeDialog({
       onClose={() => {
         onClose()
         setStakeStatus("stake")
+        setAmountInput(defaultInput)
       }}
       fullWidth
       maxWidth="xs"

--- a/src/pages/Farm/StakeDialog.tsx
+++ b/src/pages/Farm/StakeDialog.tsx
@@ -54,10 +54,11 @@ export default function StakeDialog({
   const { infiniteApproval } = useSelector((state: AppState) => state.user)
 
   const onClickStake = useCallback(async () => {
+    const errorMsg = "Unable to stake"
     try {
       if (!userGauge || !chainId || !gaugeAddress || !account || !library) {
         console.error(
-          `Could not stake: ${missingKeys({
+          `${errorMsg}: ${missingKeys({
             userGauge,
             chainId,
             gaugeAddress,
@@ -65,6 +66,7 @@ export default function StakeDialog({
             library,
           }).join(", ")} missing`,
         )
+        enqueueToast("error", errorMsg)
         return
       }
       const inputBN = parseUnits(amountInput)
@@ -100,7 +102,7 @@ export default function StakeDialog({
       setAmountInput(defaultInput)
     } catch (e) {
       console.error(e)
-      enqueueToast("error", "Unable to stake")
+      enqueueToast("error", errorMsg)
     }
   }, [
     userGauge,
@@ -115,14 +117,16 @@ export default function StakeDialog({
   ])
 
   const onClickUnstake = useCallback(async () => {
+    const errorMsg = "Unable to unstake"
     try {
       if (!userGauge || !chainId) {
         console.error(
-          `Could not unstake: ${missingKeys({
+          `${errorMsg}: ${missingKeys({
             userGauge,
             chainId,
           }).join(", ")} missing`,
         )
+        enqueueToast("error", errorMsg)
         return
       }
       const inputBN = parseUnits(amountInput)
@@ -138,7 +142,7 @@ export default function StakeDialog({
       setAmountInput(defaultInput)
     } catch (e) {
       console.error(e)
-      enqueueToast("error", "Unable to unstake")
+      enqueueToast("error", errorMsg)
     }
   }, [userGauge, amountInput, chainId, farmName, dispatch])
 

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -622,3 +622,9 @@ export function getPriceDataForPool(
     totalLocked: tokenBalancesSum1e18,
   }
 }
+
+export function missingKeys(itemsMap: { [key: string]: unknown }): string[] {
+  return Object.keys(itemsMap)
+    .map((key) => itemsMap[key] == null && key)
+    .filter(Boolean) as string[]
+}


### PR DESCRIPTION
Log when a stake/unstake fails, hide empty lp balance from the reward claim screen

Resolves #1124 #1125 