### PR TITLE
Display boost multiplier on StakingDialog modal

### DIFF
--- a/src/hooks/useUserGauge.ts
+++ b/src/hooks/useUserGauge.ts
@@ -58,10 +58,7 @@ export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
   )
 
   const boost =
-    gauge.gaugeBalance != null &&
-    !gauge.gaugeBalance.isZero() &&
-    gauge.workingBalances != null &&
-    !gauge.workingBalances.isZero()
+    gauge.gaugeBalance?.gt(Zero) && gauge.workingBalances?.gt(Zero)
       ? `${formatUnits(
           gauge.workingBalances
             .mul(BN_1E18)

--- a/src/hooks/useUserGauge.ts
+++ b/src/hooks/useUserGauge.ts
@@ -4,6 +4,7 @@ import {
   useLiquidityGaugeContract,
 } from "./useContract"
 
+import { BN_1E18 } from "../constants"
 import { BigNumber } from "@ethersproject/bignumber"
 import { ContractTransaction } from "ethers"
 import { GaugeContext } from "../providers/GaugeProvider"
@@ -11,6 +12,7 @@ import { GaugeUserReward } from "../utils/gauges"
 import { LiquidityGaugeV5 } from "../../types/ethers-contracts/LiquidityGaugeV5"
 import { UserStateContext } from "../providers/UserStateProvider"
 import { Zero } from "@ethersproject/constants"
+import { formatUnits } from "ethers/lib/utils"
 import { useActiveWeb3React } from "."
 import { useContext } from "react"
 
@@ -23,6 +25,7 @@ type UserGauge = {
   userStakedLpTokenBalance: BigNumber
   hasClaimableRewards: boolean
   userGaugeRewards: GaugeUserReward | null
+  boost: string | null
 }
 
 export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
@@ -54,6 +57,21 @@ export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
     userGaugeRewards?.claimableExternalRewards.length,
   )
 
+  const boost =
+    gauge.gaugeBalance != null &&
+    !gauge.gaugeBalance.isZero() &&
+    gauge.workingBalances != null &&
+    !gauge.workingBalances.isZero()
+      ? `${formatUnits(
+          gauge.workingBalances
+            .mul(BN_1E18)
+            .div(gauge.gaugeBalance)
+            .mul(BigNumber.from(25))
+            .div(BigNumber.from(10)),
+          18,
+        )}x`
+      : "-"
+
   return {
     stake: gaugeContract["deposit(uint256)"],
     unstake: gaugeContract["withdraw(uint256)"],
@@ -62,6 +80,7 @@ export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
       if (hasExternalRewards) {
         promises.push(gaugeContract["claim_rewards(address)"](account))
       }
+
       return Promise.all(promises)
     },
     hasClaimableRewards: hasSDLRewards || hasExternalRewards,
@@ -70,5 +89,6 @@ export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
       userState.tokenBalances?.[lpToken.address] || Zero,
     userStakedLpTokenBalance: userGaugeRewards?.amountStaked || Zero,
     userGaugeRewards: userGaugeRewards || null,
+    boost,
   }
 }

--- a/src/pages/Farm/StakeDialog.tsx
+++ b/src/pages/Farm/StakeDialog.tsx
@@ -157,6 +157,10 @@ export default function StakeDialog({
                 ),
               )}
             </Box>
+            <Box>
+              <Typography>My Boost</Typography>
+              {userGauge.boost}
+            </Box>
             <Button
               variant="outlined"
               size="large"


### PR DESCRIPTION
***Description***: On the staking dialog modal, user's current boost multiplier will be calculated and displayed. If the user hasn't provided LP or staked any asset, the multiplier will show up as `-`
![image](https://user-images.githubusercontent.com/24193788/175423892-9dbeb0a0-674a-48cd-b727-0e797348df76.png)
![image](https://user-images.githubusercontent.com/24193788/175423909-4100240e-7381-4930-8fec-152560ee57b4.png)
