### PR TITLE
Allow claiming of minichef rewards in token dialog

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -12,6 +12,7 @@
   "claimAll": "Claim All",
   "claimRewards": "Claim Rewards",
   "claimForAllPools": "Claim for all Pools",
+  "claimForAllOutdatedPools": "Claim for all Outdated Pools",
   "claimableSPA": "Claimable SPA",
   "status": "Status",
   "paused": "Paused",

--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -282,6 +282,31 @@ export default function TokenClaimDialog({
                   )
                 )
               })}
+          {/* Case when user has rewards left to claim on minichef */}
+          {gaugesAreActive && (
+            <>
+              <Typography sx={{ mt: 2 }} variant="h2">
+                Outdated Rewards
+              </Typography>
+              {allPoolsWithRewards
+                .filter((pool) => rewardBalances[pool.poolName].gt(Zero))
+                .map((pool, i, arr) => (
+                  <React.Fragment key={`${pool.poolName}-outdated`}>
+                    <ClaimListItem
+                      items={[
+                        [pool.poolName, rewardBalances[pool.poolName] || Zero],
+                      ]}
+                      claimCallback={() => claimPoolReward(pool)}
+                      status={
+                        claimsStatuses["allPools"] ||
+                        claimsStatuses[pool.poolName]
+                      }
+                    />
+                    {i < arr.length - 1 && <Divider key={i} />}
+                  </React.Fragment>
+                ))}
+            </>
+          )}
         </List>
 
         <Typography my={3}>

--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -283,7 +283,7 @@ export default function TokenClaimDialog({
                 )
               })}
           {/* Case when user has rewards left to claim on minichef */}
-          {gaugesAreActive && (
+          {gaugesAreActive && poolsWithUserRewards.length > 0 && (
             <>
               <Typography sx={{ mt: 2 }} variant="h2">
                 Outdated Rewards
@@ -325,7 +325,7 @@ export default function TokenClaimDialog({
         </Typography>
 
         {/* TODO: Follow up potentially P1 for gauges */}
-        {!gaugesAreActive && (
+        {gaugesAreActive && poolsWithUserRewards.length > 0 && (
           <Button
             variant="contained"
             color="primary"
@@ -334,7 +334,7 @@ export default function TokenClaimDialog({
             disabled={poolsWithUserRewards.length < 2}
             onClick={() => claimAllPoolsRewards(poolsWithUserRewards)}
           >
-            {t("claimForAllPools")}
+            {t("claimForAllOutdatedPools")}
           </Button>
         )}
       </Box>


### PR DESCRIPTION
This will render minichef "outdated" lp rewards for the user to claim if there are pools with rewards to claim. This was not accounted for initially.