### PR TITLE
Patch to claim tokens on side chains

### DIFF
--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -428,12 +428,10 @@ function useRewardClaims() {
         const pid = pool.miniChefRewardsPid
         if (pid === null) return
         updateClaimStatus(pool.poolName, STATUSES.PENDING)
-        let txn: ContractTransaction
-        if (chainId === ChainId.MAINNET) {
-          txn = await rewardsContract.harvest(pid, account)
-        } else {
-          txn = await rewardsContract.deposit(pid, Zero, account)
-        }
+        const txn: ContractTransaction = await rewardsContract.harvest(
+          pid,
+          account,
+        )
         await enqueuePromiseToast(chainId, txn.wait(), "claim", {
           poolName: pool.poolName,
         })
@@ -530,15 +528,7 @@ function useRewardClaims() {
         const calls = await Promise.all(
           pools.map((pool) => {
             const pid = pool.miniChefRewardsPid as number
-            if (chainId === ChainId.MAINNET) {
-              return rewardsContract.populateTransaction.harvest(pid, account)
-            } else {
-              return rewardsContract.populateTransaction.deposit(
-                pid,
-                Zero,
-                account,
-              )
-            }
+            return rewardsContract.populateTransaction.harvest(pid, account)
           }),
         )
         updateClaimStatus("all", STATUSES.PENDING)


### PR DESCRIPTION
***Description***: Since SDL now exists on side chains, rewards contract no longer needs to call .deposit() with amount Zero on non-Mainnet networks. Now, we can call .harvest() directly.