### PR TITLE
Fix boost math and decimal

### DIFF
--- a/src/hooks/useUserGauge.ts
+++ b/src/hooks/useUserGauge.ts
@@ -56,7 +56,7 @@ export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
     }
 
     void fetchVeSdlBalance()
-  }, [votingEscrowContract])
+  }, [votingEscrowContract, account])
 
   if (
     !gaugeAddress ||

--- a/src/hooks/useUserGauge.ts
+++ b/src/hooks/useUserGauge.ts
@@ -75,10 +75,12 @@ export default function useUserGauge(gaugeAddress?: string): UserGauge | null {
     userGaugeRewards?.claimableExternalRewards.length,
   )
 
-  const userLPAmount = gauge.gaugeBalance
-  const totalLpAmout = gauge.gaugeTotalSupply
-  const workingBalance = gauge.workingBalances
-  const workingSupply = gauge.workingSupply
+  const {
+    gaugeBalance: userLPAmount,
+    gaugeTotalSupply: totalLpAmout,
+    workingBalances: workingBalance,
+    workingSupply,
+  } = gauge
 
   const boost = userLPAmount
     ? calculateBoost(

--- a/src/pages/Farm/StakeDialog.tsx
+++ b/src/pages/Farm/StakeDialog.tsx
@@ -187,7 +187,7 @@ export default function StakeDialog({
             </Box>
             <Box>
               <Typography>My Boost</Typography>
-              {userGauge.boost}
+              {userGauge.boost ? formatBNToString(userGauge.boost, 18, 2) : "-"}
             </Box>
             <Button
               variant="outlined"

--- a/src/pages/VeSDL/VeTokenCalculator.tsx
+++ b/src/pages/VeSDL/VeTokenCalculator.tsx
@@ -72,9 +72,11 @@ export default function VeTokenCalculator({
       .mul(userLPAmountBN)
       .div(totalLPAmountBN.add(userLPAmountBN))
 
+  const newTotalLPDeposit = totalLPAmountBN.add(userLPAmountBN)
+
   const boost = calculateBoost(
     userLPAmountBN,
-    totalLPAmountBN,
+    newTotalLPDeposit,
     gauge.workingBalances,
     gauge.workingSupply,
     parseEther(userVeSDLInputAmount || "0"),
@@ -85,7 +87,7 @@ export default function VeTokenCalculator({
     minVeSDL &&
     calculateBoost(
       userLPAmountBN,
-      totalLPAmountBN,
+      newTotalLPDeposit,
       gauge.workingBalances,
       gauge.workingSupply,
       minVeSDL,

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -449,15 +449,13 @@ export const calculateBoost = (
   totalWorkingSupply: BigNumber,
   userBalanceVeSDL: BigNumber,
   totalSupplyVeSDL: BigNumber,
-): BigNumber | undefined => {
+): BigNumber | null => {
   if (totalSupplyVeSDL.isZero()) return parseEther("1")
 
   let lim = userLPAmount.mul(BigNumber.from(40)).div(BigNumber.from(100))
 
-  const newTotalLPDeposit = totalLPDeposit.add(userLPAmount)
-
   lim = lim.add(
-    newTotalLPDeposit
+    totalLPDeposit
       .mul(userBalanceVeSDL)
       .div(totalSupplyVeSDL)
       .mul(BigNumber.from(60))


### PR DESCRIPTION
## What does this PR do?

- Boost math
 Boost  logic is based on the following logic.
```
(min((userLiquidity*40/100) + TotalLiquidity*UserVeSdlBalance/TotalVeSdlBalance*(100-40)/100 , UserLiquidity)) / (UserLiquidity*40/100)

```

- UserVeSdlBalance = 0
Then boost = (min(UserLiquidity*40/100, UserLiquidity) / (UserLiquidity*40/100) = 1.0

- UserVeSdlBalance = TotalVeSdlBalance
Then `TotalLiquidity*UserVeSdlBalance/TotalVeSdlBalance*(100-40)/100` will be `TotalLiquidity*(100-40)/100` .
numerator will be UserLiquidity.

So, boost = UserLiquidity/(UserLiquidity * 40 /100) = 2.5,  this is max value of the bost.

- veSDL for max boost
When `userLiquidity*40/100) + TotalLiquidity*UserVeSdlBalance/TotalVeSdlBalance*(100-40)/100` === `UserLiquidity`, user can have max boost under user's Liquidity.
In this case, `TotalLiquidity*UserVeSdlBalance/TotalVeSdlBalance` should be  `UserLiqudiity` for maxboost
So, `UserVeSdlBalance = (UserLiquidity / TotalLiquidity ) * TotalVeSdlBalance`. This is veSDL balance for max boost.


## Context

closes: https://github.com/saddle-finance/saddle-frontend/issues/1138

