### PR TITLE
Farm header zInex fix and prevent to close drawer when click account …

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -141,11 +141,10 @@ function TopMenu(): ReactElement {
           anchor="right"
           PaperProps={{ sx: { borderWidth: 0, borderRadius: 0 } }}
         >
-          <Stack
-            m={(theme) => theme.spacing(5, 5, 0, 8)}
-            onClick={() => setDrawerOpen(false)}
-          >
-            <MenuList />
+          <Stack m={(theme) => theme.spacing(5, 5, 0, 8)}>
+            <Stack onClick={() => setDrawerOpen(false)}>
+              <MenuList />
+            </Stack>
             <Divider />
             <Box py={2}>
               <Web3Status />

--- a/src/pages/Farm/Farm.tsx
+++ b/src/pages/Farm/Farm.tsx
@@ -42,7 +42,7 @@ export default function Farm(): JSX.Element {
         position="sticky"
         top={0}
         bgcolor={(theme) => theme.palette.background.paper}
-        zIndex={(theme) => theme.zIndex.tooltip - 1}
+        zIndex={(theme) => theme.zIndex.mobileStepper - 1}
         py={2}
       >
         <FarmListHeader />


### PR DESCRIPTION
## What does this PR do?
 - Farm Header zIndex
I gave `display:"stick"` to `FarmHeader` to pin farm header to the top while user scroll the farm list. The button's zIndex is greater than `Box` so I gave zIndex of `theme.zIndex.toolTip-1` . But it makes FarmHeader displays on the menu and drawer.

The zIndex on MUI is the following

```
const zIndex = {
  mobileStepper: 1000,
  speedDial: 1050,
  appBar: 1100,
  drawer: 1200,
  modal: 1300,
  snackbar: 1400,
  tooltip: 1500
};
```
As we can see above, `theme.zIndex.mobileStepper-1` will be enough for FarmHeader.

- Prevent to close Drawer when click Account detail.
For mobile responsive I moved Account detail to the drawer. Also now when user click menu or account detail, the drawer closed. But it makes issue for displaying account detail because account detail is having Dialog and so as a result, account detail displays on Drawer.
To prevent this , I disabled to close drawer when user click AccountDetail.
This is not ideal, and will be updated after updating modal logic.

## Screenshot
![Screen Shot 2022-06-27 at 9 37 28 AM](https://user-images.githubusercontent.com/75422800/175875138-b6aa17e5-5917-461b-b47b-8011f498e57b.png)

![Screen Shot 2022-06-27 at 9 37 38 AM](https://user-images.githubusercontent.com/75422800/175875160-47e1432b-c765-4c10-b676-e6fb0545481a.png)

