### PR TITLE
Fix SLP fetching issue

### DIFF
--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -217,7 +217,7 @@ function SDLPrice({ sdlPrice }: SDLPriceProps): ReactElement | null {
   if (sdlPrice === undefined) return null
 
   const SUSHI_WETH_SDL_POOL_URL =
-    "https://app.sushi.com/analytics/pools/0x0c6f06b32e6ae0c110861b8607e67da594781961?chainId=1"
+    "https://ethereum.sushi.com/swap?inputCurrency=ETH&outputCurrency=0xf1Dc500FdE233A4055e25e5BbF516372BC4F6871"
   return (
     <Button
       variant="contained"

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -98,13 +98,17 @@ export function useMasterRegistry(): MasterRegistry | null {
   const contractAddress = chainId
     ? MASTER_REGISTRY_CONTRACT_ADDRESSES[chainId]
     : undefined
-  return useContract(contractAddress, MASTER_REGISTRY_ABI) as MasterRegistry
+  return useContract(
+    contractAddress,
+    MASTER_REGISTRY_ABI,
+    false,
+  ) as MasterRegistry
 }
 
 export const POOL_REGISTRY_NAME = formatBytes32String("PoolRegistry")
 
 export function usePoolRegistry(): PoolRegistry | null {
-  const { account, library } = useActiveWeb3React()
+  const { library } = useActiveWeb3React()
   const masterRegistryContract = useMasterRegistry()
   const [contractAddress, setContractAddress] = useState<string | undefined>()
   useEffect(() => {
@@ -126,18 +130,18 @@ export function usePoolRegistry(): PoolRegistry | null {
   }, [masterRegistryContract])
 
   return useMemo(() => {
-    if (!library || !account || !contractAddress) return null
+    if (!library || !contractAddress) return null
     return getContract(
       contractAddress,
       POOL_REGISTRY_ABI,
       library,
-      account,
+      undefined,
     ) as PoolRegistry
-  }, [contractAddress, library, account])
+  }, [contractAddress, library])
 }
 
 export function usePoolRegistryMultiCall(): MulticallContract<PoolRegistry> | null {
-  const { account, library } = useActiveWeb3React()
+  const { library } = useActiveWeb3React()
   const masterRegistryContract = useMasterRegistry()
   const [contractAddress, setContractAddress] = useState<string | undefined>()
   useEffect(() => {
@@ -159,12 +163,12 @@ export function usePoolRegistryMultiCall(): MulticallContract<PoolRegistry> | nu
   }, [masterRegistryContract])
 
   return useMemo(() => {
-    if (!library || !account || !contractAddress) return null
+    if (!library || !contractAddress) return null
     return createMultiCallContract<PoolRegistry>(
       contractAddress,
       POOL_REGISTRY_ABI,
     )
-  }, [contractAddress, library, account])
+  }, [contractAddress, library])
 }
 
 export const PERMISSIONLESS_DEPLOYER_NAME = formatBytes32String(
@@ -260,6 +264,7 @@ export function useSynthetixExchangeRatesContract(): SynthetixExchangeRate | nul
   return useContract(
     contractAddress,
     SYNTHETIX_EXCHANGE_RATE_CONTRACT_ABI,
+    false,
   ) as SynthetixExchangeRate
 }
 
@@ -368,7 +373,11 @@ export function useGaugeControllerContract(): GaugeController | null {
   const contractAddress = chainId
     ? GAUGE_CONTROLLER_ADDRESSES[chainId]
     : undefined
-  return useContract(contractAddress, GAUGE_CONTROLLER_ABI) as GaugeController
+  return useContract(
+    contractAddress,
+    GAUGE_CONTROLLER_ABI,
+    false,
+  ) as GaugeController
 }
 
 export const useSdlContract = (): Sdl => {
@@ -407,7 +416,7 @@ export const useSdlWethSushiPairContract = (): SushiPool | null => {
   const contractAddress = chainId
     ? SDL_WETH_SUSHI_LP_CONTRACT_ADDRESSES[chainId]
     : undefined
-  return useContract(contractAddress, SUSHI_POOL_ABI) as SushiPool
+  return useContract(contractAddress, SUSHI_POOL_ABI, false) as SushiPool
 }
 
 export function useLiquidityGaugeContract(


### PR DESCRIPTION
For some reason, the codebase had issues fetching information about the SLP pair, causing the TVL of the pair not to render. This was resolved by remove the reference to account from `useSdlWethSushiPairContract`. I removed it from a few other places as well for good housekeeping.

I also update the sushi link from the analytics page to https://ethereum.sushi.com/swap?inputCurrency=ETH&outputCurrency=0xf1Dc500FdE233A4055e25e5BbF516372BC4F6871