### PR TITLE
Fix gauge rewards claiming logic

### DIFF
--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -468,8 +468,8 @@ function useRewardClaims() {
       try {
         updateClaimStatus(gauge.gaugeName, STATUSES.PENDING)
         const claimPromises = []
-        const minterRewards = gauge.rewards.filter(({ isSDL }) => isSDL)
-        const gaugeRewards = gauge.rewards.filter(({ isSDL }) => !isSDL)
+        const minterRewards = gauge.rewards.filter(({ isMinter }) => isMinter)
+        const gaugeRewards = gauge.rewards.filter(({ isMinter }) => !isMinter)
         if (minterRewards.length > 0) {
           claimPromises.push(gaugeMinterContract.mint(gauge.address))
         }

--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -354,7 +354,10 @@ function ClaimListItem({
   status?: STATUSES
 }): ReactElement {
   const { t } = useTranslation()
-  const disabled = status === STATUSES.PENDING || status === STATUSES.SUCCESS
+  const disabled =
+    status === STATUSES.PENDING ||
+    status === STATUSES.SUCCESS ||
+    items.every(([, amount]) => amount.isZero())
   // @dev - our formatting assumes all tokens are 1e18
   return (
     <ListItem>

--- a/src/utils/gauges.ts
+++ b/src/utils/gauges.ts
@@ -47,6 +47,7 @@ export type GaugeReward = {
   periodFinish: BigNumber
   rate: BigNumber
   tokenAddress: string
+  isSDL?: boolean
 }
 
 export type LPTokenAddressToGauge = Partial<{
@@ -212,6 +213,7 @@ export async function getGaugeData(
           periodFinish: BN_MSIG_SDL_VEST_END_TIMESTAMP,
           rate: sdlRate,
           tokenAddress: SDL_TOKEN_ADDRESSES[chainId].toLowerCase(),
+          isSDL: true,
         }
         if (!lpTokenAddress) return previousGaugeData
         return {
@@ -234,8 +236,9 @@ export async function getGaugeData(
                 periodFinish: reward.period_finish,
                 rate: reward.rate,
                 tokenAddress: reward.token.toLowerCase(),
+                isSDL: false,
               }))
-              .concat([sdlReward]),
+              .concat(sdlRate.gt(Zero) ? [sdlReward] : []),
           } as Gauge,
         }
       },

--- a/src/utils/gauges.ts
+++ b/src/utils/gauges.ts
@@ -47,7 +47,7 @@ export type GaugeReward = {
   periodFinish: BigNumber
   rate: BigNumber
   tokenAddress: string
-  isSDL?: boolean
+  isMinter: boolean
 }
 
 export type LPTokenAddressToGauge = Partial<{
@@ -213,7 +213,7 @@ export async function getGaugeData(
           periodFinish: BN_MSIG_SDL_VEST_END_TIMESTAMP,
           rate: sdlRate,
           tokenAddress: SDL_TOKEN_ADDRESSES[chainId].toLowerCase(),
-          isSDL: true,
+          isMinter: true,
         }
         if (!lpTokenAddress) return previousGaugeData
         return {
@@ -236,7 +236,7 @@ export async function getGaugeData(
                 periodFinish: reward.period_finish,
                 rate: reward.rate,
                 tokenAddress: reward.token.toLowerCase(),
-                isSDL: false,
+                isMinter: false,
               }))
               .concat(sdlRate.gt(Zero) ? [sdlReward] : []),
           } as Gauge,


### PR DESCRIPTION
Now explicitly check that that we have minter rewards before creating minter txn, check that we have gauge rewards before creating gauge claim txn. Give more explicit feedback to user. 