### PR TITLE
fixed multiscan link for kava and potential coingecko id

### DIFF
--- a/src/constants/networks.ts
+++ b/src/constants/networks.ts
@@ -36,7 +36,7 @@ export const COINGECKO_PLATFORM_ID: Record<ChainId, string | null> = {
   [ChainId.EVMOS]: "evmos",
   [ChainId.EVMOS_TESTNET]: null,
   [ChainId.KAVA_TESTNET]: null,
-  [ChainId.KAVA]: null,
+  [ChainId.KAVA]: "kava",
   [ChainId.HARDHAT]: null,
 }
 
@@ -138,14 +138,14 @@ export const DEV_SUPPORTED_NETWORKS: SupportedNetworks = {
     blockExplorerUrls: ["https://evm.evmos.dev"],
   },
   [ChainId.KAVA_TESTNET]: {
-    chainId: hexlify(2221),
+    chainId: "0x8AD",
     chainName: "Kava Testnet",
     nativeCurrency: {
       name: "Kava",
       symbol: "KAVA",
       decimals: 18,
     },
-    rpcUrls: ["https://evm.evm-alpha.kava.io"],
+    rpcUrls: ["https://evm.testnet.kava.io"],
     blockExplorerUrls: ["https://explorer.evm-alpha.kava.io"],
   },
 }

--- a/src/utils/getEtherscanLink.ts
+++ b/src/utils/getEtherscanLink.ts
@@ -27,6 +27,9 @@ export function getMultichainScanLink(
       break
     case ChainId.KAVA:
       chainScanDomain = "explorer.kava.io"
+      if (type === "token") {
+        type = "address" // Kava uses the address keyword instead of token
+      }
       break
     default:
       chainScanDomain = "etherscan.io"


### PR DESCRIPTION
The link was for Kava needs a special case for links to contracts that's different from the other networks.

Hexlify function doesn't seem to play nicely anymore.

kava testnet rpc url needs updating.

added the potential coingecko platform id