### PR TITLE
Fix Coingecko id of USX token

### DIFF
--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1330,7 +1330,7 @@ export const USX = new Token(
   USX_CONTRACT_ADDRESSES,
   18,
   "USX",
-  "dforce-usd",
+  "token-dforce-usd",
   "dForce USD",
 )
 


### PR DESCRIPTION
## Description

Because of wrong `coingecko id` of `USX` `updateTokenPrice` doesn't fetch the price of USX from coingecko.

We can check coingecko id from `coingecko api` (https://api.coingecko.com/api/v3/coins/list)

![image](https://user-images.githubusercontent.com/75422800/181356592-83d4c166-9c70-47ba-8952-d84b52f3cad1.png)
