### PR TITLE
Wait for basicPools to load before triggering redirect

### DIFF
--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -122,10 +122,12 @@ export default function App(): ReactElement {
                                     key={`${pool.poolName}-withdraw`}
                                   />
                                 ))}
-                                <Redirect
-                                  from="/pools/:route/:action"
-                                  to="/pools"
-                                />
+                                {basicPools && (
+                                  <Redirect
+                                    from="/pools/:route/:action"
+                                    to="/pools"
+                                  />
+                                )}
                                 <Route
                                   exact
                                   path="/pools/create"


### PR DESCRIPTION
Directly linking to a `/pools/:route/:action` triggered redirect before pools load. This forces Redirect to wait before triggering.