### PR TITLE
Date picker patch

### DIFF
--- a/src/pages/VeSDL/index.tsx
+++ b/src/pages/VeSDL/index.tsx
@@ -280,8 +280,8 @@ export default function VeSDL(): JSX.Element {
     proposedUnlockDate &&
     !isNaN(proposedUnlockDate.valueOf()) &&
     intervalToDuration({
-      start: proposedUnlockDate,
-      end: lockEnd || new Date(),
+      end: proposedUnlockDate,
+      start: lockEnd || new Date(),
     })
   const additionalLockDuration =
     duration &&


### PR DESCRIPTION
***Description***: Upon the `date-fns` package update from `2.25` -> `2.29`,  `intervalToDuration` method will throw a `RangeError` if the end date is before the start date. This PR addresses that issue by switching the start and end key of the input `Interval` object of that method.