### PR TITLE
Date Picker alternative patch

### DIFF
--- a/src/pages/VeSDL/index.tsx
+++ b/src/pages/VeSDL/index.tsx
@@ -19,12 +19,12 @@ import {
   format,
   formatDuration,
   getUnixTime,
-  intervalToDuration,
   secondsToHours,
 } from "date-fns"
 import { commify, formatUnits, parseEther } from "@ethersproject/units"
 import { enUS, zhCN } from "date-fns/locale"
 import { enqueuePromiseToast, enqueueToast } from "../../components/Toastify"
+import { formatBNToString, getIntervalBetweenTwoDates } from "../../utils"
 import { useDispatch, useSelector } from "react-redux"
 import {
   useFeeDistributor,
@@ -46,7 +46,6 @@ import VeSDLWrongNetworkModal from "./VeSDLWrongNetworkModal"
 import VeTokenCalculator from "./VeTokenCalculator"
 import { Zero } from "@ethersproject/constants"
 import checkAndApproveTokenForTrade from "../../utils/checkAndApproveTokenForTrade"
-import { formatBNToString } from "../../utils"
 import { minBigNumber } from "../../utils/minBigNumber"
 import { updateLastTransactionTimes } from "../../state/application"
 import { useActiveWeb3React } from "../../hooks"
@@ -279,10 +278,7 @@ export default function VeSDL(): JSX.Element {
   const duration =
     proposedUnlockDate &&
     !isNaN(proposedUnlockDate.valueOf()) &&
-    intervalToDuration({
-      start: proposedUnlockDate,
-      end: lockEnd || new Date(),
-    })
+    getIntervalBetweenTwoDates(proposedUnlockDate, lockEnd)
   const additionalLockDuration =
     duration &&
     formatDuration(

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -38,6 +38,7 @@ import { SwapGuarded } from "../../types/ethers-contracts/SwapGuarded"
 import { TokenPricesUSD } from "../state/application"
 import { chunk } from "lodash"
 import { getAddress } from "@ethersproject/address"
+import { intervalToDuration } from "date-fns"
 import { minBigNumber } from "./minBigNumber"
 
 export function isSynthAsset(chainId: ChainId, tokenAddress: string): boolean {
@@ -703,4 +704,21 @@ export function missingKeys(itemsMap: { [key: string]: unknown }): string[] {
   return Object.keys(itemsMap)
     .map((key) => itemsMap[key] == null && key)
     .filter(Boolean) as string[]
+}
+
+export function getIntervalBetweenTwoDates(
+  firstDate: Date | null,
+  secondDate: Date | null,
+): Duration {
+  const firstDateInSeconds = firstDate
+    ? firstDate.valueOf()
+    : new Date().valueOf()
+
+  const secondDateInSeconds = secondDate
+    ? secondDate.valueOf()
+    : new Date().valueOf()
+  const startDate = new Date(Math.min(firstDateInSeconds, secondDateInSeconds))
+  const endDate = new Date(Math.max(firstDateInSeconds, secondDateInSeconds))
+
+  return intervalToDuration({ start: startDate, end: endDate })
 }

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -713,7 +713,6 @@ export function getIntervalBetweenTwoDates(
   const firstDateInSeconds = firstDate
     ? firstDate.valueOf()
     : new Date().valueOf()
-
   const secondDateInSeconds = secondDate
     ? secondDate.valueOf()
     : new Date().valueOf()


### PR DESCRIPTION
***Description:*** Upon the `date-fns` package update from 2.25 -> 2.29, `intervalToDuration` method will throw a RangeError if the end date is before the start date. This PR addresses that issue by finding the appropriate max and min between the `proposeUnlockDate` and `lockEnd` values and passing that into the `intervalToDuration` accordingly.