### PR TITLE
Revert not storing Zero values

### DIFF
--- a/src/providers/UserStateProvider.tsx
+++ b/src/providers/UserStateProvider.tsx
@@ -153,13 +153,9 @@ async function getUserTokenBalances(
         i === batchBalanceResults.length - 1
           ? NETWORK_NATIVE_TOKENS[chainId]
           : tokenAddresses[i]
-      if (!result || result.eq(Zero)) {
-        // don't store 0 balances
-        return acc
-      }
       return {
         ...acc,
-        [address]: result,
+        [address]: result || Zero,
       }
     }, {} as UserTokenBalances)
   } catch (e) {


### PR DESCRIPTION
there's a bug with some logic mapping causing swap input to crash on token selection when this change in place. I still don't know the root cause but this unblocks Swap for now.