### PR TITLE
Display minichef APRs

### DIFF
--- a/src/components/PoolOverview.tsx
+++ b/src/components/PoolOverview.tsx
@@ -47,7 +47,7 @@ export default function PoolOverview({
     reserve: poolData.reserve
       ? formatBNToShortString(poolData.reserve, 18)
       : "-",
-    apy: poolData.apy ? `${formatBNToPercentString(poolData.apy, 18, 2)}` : "-",
+    apy: poolData.apy ? formatBNToPercentString(poolData.apy, 18, 2) : "-",
     volume: poolData.volume
       ? `$${formatBNToShortString(poolData.volume, 18)}`
       : "-",
@@ -56,6 +56,7 @@ export default function PoolOverview({
       18,
     ),
     sdlPerDay: formatBNToShortString(poolData?.sdlPerDay || Zero, 18),
+    minichefSDLInfo: formatBNToPercentString(poolData.minichefSDLApr, 18, 2),
   }
   const hasShare = !!userShareData?.usdBalance.gt(Zero)
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -77,6 +78,14 @@ export default function PoolOverview({
     }
   }, [poolData.isGuarded, shouldMigrate, poolData.isPaused])
 
+  let minichefSDLInfo = null
+  if (!gaugesAreActive) {
+    if (poolData.minichefSDLApr.gt(Zero)) {
+      minichefSDLInfo = ["SDL apr", formattedData.minichefSDLInfo]
+    } else if (poolData.sdlPerDay?.gt(Zero)) {
+      minichefSDLInfo = ["SDL/24h", formattedData.sdlPerDay]
+    }
+  }
   return (
     <Paper
       sx={{
@@ -167,7 +176,13 @@ export default function PoolOverview({
           )}
         </StyledGrid>
         <StyledGrid item xs={6} lg={2.5} disabled={disableText}>
-          {poolData.sdlPerDay?.gt(Zero) && !gaugesAreActive && (
+          {formattedData.apy && (
+            <div>
+              <Typography component="span">{`${t("apy")}`}: </Typography>
+              <Typography component="span">{formattedData.apy}</Typography>
+            </div>
+          )}
+          {minichefSDLInfo && (
             <Box sx={{ display: "flex", alignItems: "center" }}>
               <Typography variant="subtitle1" mr={1}>
                 <Link
@@ -176,19 +191,13 @@ export default function PoolOverview({
                   rel="noreferrer"
                   sx={{ textDecoration: "underline" }}
                 >
-                  SDL/24h
+                  {minichefSDLInfo[0]}
                 </Link>
               </Typography>
               <img src={logo} width="24px" />
               :&nbsp;
-              <Typography>{formattedData.sdlPerDay}</Typography>
+              <Typography>{minichefSDLInfo[1]}</Typography>
             </Box>
-          )}
-          {formattedData.apy && (
-            <div>
-              <Typography component="span">{`${t("apy")}`}: </Typography>
-              <Typography component="span">{formattedData.apy}</Typography>
-            </div>
           )}
           {gaugesAreActive ? (
             <GaugeRewardsDisplay aprs={poolData.gaugeAprs} />

--- a/src/hooks/usePoolData.ts
+++ b/src/hooks/usePoolData.ts
@@ -1,10 +1,15 @@
-import { A_PRECISION, PoolTypes } from "./../constants/index"
+import { A_PRECISION, BN_1E18, PoolTypes } from "./../constants/index"
 import { AprsContext, GaugeApr } from "./../providers/AprsProvider"
 import {
   Partners,
   getThirdPartyDataForPool,
 } from "../utils/thirdPartyIntegrations"
-import { bnSum, calculateFraction, getPriceDataForExpandedPool } from "../utils"
+import {
+  bnSum,
+  calculateFraction,
+  getPriceDataForExpandedPool,
+  shiftBNDecimals,
+} from "../utils"
 import { useContext, useEffect, useState } from "react"
 
 import { AppState } from "../state"
@@ -43,6 +48,7 @@ export interface PoolDataType {
   virtualPrice: BigNumber
   volume: BigNumber | null
   sdlPerDay: BigNumber | null
+  minichefSDLApr: BigNumber
   isPaused: boolean
   poolAddress: string
   gaugeAprs: GaugeApr[] | null
@@ -105,6 +111,7 @@ const emptyPoolData = {
   sdlPerDay: null,
   isGuarded: false,
   isMetaSwap: false,
+  minichefSDLApr: Zero,
   poolType: PoolTypes.OTHER,
 } as PoolDataType
 
@@ -247,6 +254,20 @@ export default function usePoolData(name?: string): PoolDataHookReturnType {
           expandedPool.poolAddress
         ] || { oneDayVolume: null, apy: null, utilization: null }
 
+        let [amountStakedInMinichefUSD, minichefSDLApr] = [Zero, Zero]
+        if (poolMinichefData && tokenPricesUSD?.SDL) {
+          amountStakedInMinichefUSD = priceDataForPool.tokenBalancesSumUSD
+            .mul(poolMinichefData.pctOfSupplyStaked)
+            .div(BN_1E18)
+          const rewardPerYear = poolMinichefData.sdlPerDay.mul(365) // 1e18
+          const rewardPerYearUSD = rewardPerYear.mul(
+            parseUnits(tokenPricesUSD.SDL.toFixed(3), 3),
+          ) // 1e18 * 1e3 = 1e21
+          minichefSDLApr = shiftBNDecimals(rewardPerYearUSD, 15).div(
+            amountStakedInMinichefUSD,
+          ) // (1e21 * 1e15 = 1e36) / 1e18 = 1e18
+        }
+
         const poolData = {
           name: poolName,
           tokens: poolTokens,
@@ -275,8 +296,8 @@ export default function usePoolData(name?: string): PoolDataHookReturnType {
 
           gaugeAprs: poolGaugeAprs ?? null,
           aprs, // rm - move to minichef provider + thirdparty provider
-          sdlPerDay:
-            minichefData?.pools[expandedPool.poolAddress]?.sdlPerDay || Zero,
+          sdlPerDay: poolMinichefData?.sdlPerDay || Zero,
+          minichefSDLApr,
           claimableAmount, // move to minichef provider
         }
         const userShareData = account

--- a/src/providers/MinichefProvider.tsx
+++ b/src/providers/MinichefProvider.tsx
@@ -18,13 +18,18 @@ export default function MinichefProvider({
         setRewardsData(null)
         return
       }
-      const poolAddresses = Object.values(pools || {}).map(
-        ({ poolAddress }) => poolAddress,
+      const poolsData = Object.values(pools || {}).map(
+        ({ poolAddress, lpToken, miniChefRewardsPid, lpTokenSupply }) => ({
+          poolAddress,
+          lpToken,
+          miniChefRewardsPid,
+          lpTokenSupply,
+        }),
       )
       const rewardsData = await getMinichefRewardsPoolsData(
         library,
         chainId,
-        poolAddresses,
+        poolsData,
       )
       setRewardsData(rewardsData)
     }

--- a/src/providers/UserStateProvider.tsx
+++ b/src/providers/UserStateProvider.tsx
@@ -56,7 +56,14 @@ export default function UserStateProvider({
       const minichefDataPromise = getMinichefRewardsUserData(
         library,
         chainId,
-        Object.values(basicPools).map(({ poolAddress }) => poolAddress),
+        Object.values(basicPools).map(
+          ({ poolAddress, lpToken, miniChefRewardsPid, lpTokenSupply }) => ({
+            poolAddress,
+            lpToken,
+            miniChefRewardsPid,
+            lpTokenSupply,
+          }),
+        ),
         account,
       )
       const gaugeRewardsPromise = gauges


### PR DESCRIPTION
- update `utils/minichef` to calculate the amount of lpToken staked in minichef for each pool
- update `usePoolData` to calculate minichef apr from amount staked, tvl, and sdl price
- update `PoolOverview` to display apr