### PR TITLE
Fix breaking of change account text

### DIFF
--- a/src/components/AccountDetails.tsx
+++ b/src/components/AccountDetails.tsx
@@ -90,20 +90,21 @@ export default function AccountDetail({ openOptions }: Props): ReactElement {
               {ethBalanceFormatted}&#926;
             </Typography>
           </Box>
+        </Box>
+        <Box display="flex" gap="16px" justifyContent="space-between" mt="16px">
           <Box display="flex" alignItems="center">
             {account && <Copy toCopy={account} />}
           </Box>
-          <Box display="flex" alignItems="center">
-            <Button
-              onClick={() => {
-                openOptions()
-              }}
-              startIcon={<ChangeIcon />}
-              data-testid="changeAccountBtn"
-            >
-              {t("changeAccount")}
-            </Button>
-          </Box>
+
+          <Button
+            onClick={() => {
+              openOptions()
+            }}
+            startIcon={<ChangeIcon />}
+            data-testid="changeAccountBtn"
+          >
+            {t("changeAccount")}
+          </Button>
         </Box>
       </DialogContent>
       <Box bgcolor={theme.palette.background.paper} p={3}>

--- a/src/components/Dialog.tsx
+++ b/src/components/Dialog.tsx
@@ -17,7 +17,12 @@ export default function Dialog({
     <MuiDialog {...props} onClose={hideClose ? undefined : onClose}>
       {!hideClose && (
         <IconButton
-          sx={{ position: "absolute", right: 16, top: 16 }}
+          sx={{
+            position: "absolute",
+            right: 16,
+            top: 16,
+            zIndex: (theme) => theme.zIndex.modal + 1,
+          }}
           onClick={() => onClose()}
           data-testid="dialogCloseBtn"
         >


### PR DESCRIPTION
### Description

On iOS mobile, user can’t close “Account” menu and overlapping text. 
![image](https://user-images.githubusercontent.com/75422800/191836190-f801a61c-50b8-41f7-bf6a-77e878788a25.png)

Reported from [discord](https://discord.com/channels/780508954916290610/780521388959727627/1022581326571909191).

- Increased the zIndex of close icon button of Dialog
- Changed the layout for `Change account` button.


### Screenshot

![image](https://user-images.githubusercontent.com/75422800/191836881-162ca2d1-9612-4e5c-9ca2-c7848c177f98.png)

