### PR TITLE
Address Registry Provider

### DIFF
--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -67,6 +67,9 @@ import { VotingEscrow } from "../../types/ethers-contracts/VotingEscrow"
 import { formatBytes32String } from "@ethersproject/strings"
 import { useActiveWeb3React } from "./index"
 
+export const POOL_REGISTRY_NAME = formatBytes32String("PoolRegistry")
+export const CHILD_GAUGE_FACTORY_NAME = formatBytes32String("ChildGaugeFactory")
+
 // returns null on errors
 function useContract(
   address: string | undefined,
@@ -102,8 +105,6 @@ export function useMasterRegistry(): MasterRegistry | null {
     false,
   ) as MasterRegistry
 }
-
-export const POOL_REGISTRY_NAME = formatBytes32String("PoolRegistry")
 
 export function usePoolRegistry(): PoolRegistry | null {
   const { library } = useActiveWeb3React()

--- a/src/pages/App.tsx
+++ b/src/pages/App.tsx
@@ -17,6 +17,7 @@ import MinichefProvider from "../providers/MinichefProvider"
 import Pages from "./Pages"
 import PendingSwapsProvider from "../providers/PendingSwapsProvider"
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools"
+import RegistryAddressProvider from "../providers/RegistryAddressProvider"
 import RewardsBalancesProvider from "../providers/RewardsBalancesProvider"
 import { ToastContainer } from "react-toastify"
 import TokensProvider from "../providers/TokensProvider"
@@ -75,40 +76,45 @@ export default function App(): ReactElement {
       <Web3ReactManager>
         <BasicPoolsProvider>
           <MinichefProvider>
-            <GaugeProvider>
-              <TokensProvider>
-                <ExpandedPoolsProvider>
-                  <UserStateProvider>
-                    <PricesAndVoteData>
-                      <PendingSwapsProvider>
-                        <AprsProvider>
-                          <RewardsBalancesProvider>
-                            <LocalizationProvider dateAdapter={AdapterDateFns}>
-                              <AppContainer>
-                                <TopMenu />
-                                <Suspense fallback={null}>
-                                  <Pages />
-                                </Suspense>
-                                <WrongNetworkModal />
-                                <Version />
-                                <ToastContainer
-                                  theme={
-                                    theme.palette.mode === "dark"
-                                      ? "dark"
-                                      : "light"
-                                  }
-                                  position="top-left"
-                                />
-                              </AppContainer>
-                            </LocalizationProvider>
-                          </RewardsBalancesProvider>
-                        </AprsProvider>
-                      </PendingSwapsProvider>
-                    </PricesAndVoteData>
-                  </UserStateProvider>
-                </ExpandedPoolsProvider>
-              </TokensProvider>
-            </GaugeProvider>
+            <RegistryAddressProvider>
+              <GaugeProvider>
+                <TokensProvider>
+                  <ExpandedPoolsProvider>
+                    <UserStateProvider>
+                      <PricesAndVoteData>
+                        <PendingSwapsProvider>
+                          <AprsProvider>
+                            <RewardsBalancesProvider>
+                              <LocalizationProvider
+                                dateAdapter={AdapterDateFns}
+                              >
+                                <AppContainer>
+                                  <TopMenu />
+                                  <Suspense fallback={null}>
+                                    <Pages />
+                                  </Suspense>
+                                  <WrongNetworkModal />
+                                  <Version />
+                                  <ToastContainer
+                                    theme={
+                                      theme.palette.mode === "dark"
+                                        ? "dark"
+                                        : "light"
+                                    }
+                                    position="top-left"
+                                  />
+                                </AppContainer>
+                              </LocalizationProvider>
+                            </RewardsBalancesProvider>
+                          </AprsProvider>
+                        </PendingSwapsProvider>
+                      </PricesAndVoteData>
+                    </UserStateProvider>
+                  </ExpandedPoolsProvider>
+                </TokensProvider>
+                <RegistryAddressProvider />
+              </GaugeProvider>
+            </RegistryAddressProvider>
           </MinichefProvider>
         </BasicPoolsProvider>
       </Web3ReactManager>

--- a/src/providers/RegistryAddressProvider.tsx
+++ b/src/providers/RegistryAddressProvider.tsx
@@ -1,0 +1,69 @@
+import {
+  CHILD_GAUGE_FACTORY_NAME,
+  useMasterRegistry,
+} from "../hooks/useContract"
+import {
+  EMPTY_LOADABLE,
+  LoadableType,
+  useLoadingState,
+} from "../utils/loadable"
+import React, { ReactElement, useEffect } from "react"
+import { ChainId } from "../constants"
+import { parseBytes32String } from "ethers/lib/utils"
+import { useActiveWeb3React } from "../hooks"
+
+export type RegistryAddress = LoadableType<Partial<Record<string, string>>>
+
+export const RegistryAddressContext = React.createContext<RegistryAddress>({
+  ...EMPTY_LOADABLE,
+  data: {},
+})
+
+export default function RegistryAddressProvider({
+  children,
+}: React.PropsWithChildren<unknown>): ReactElement {
+  const { chainId } = useActiveWeb3React()
+  const masterRegistry = useMasterRegistry()
+  const { state, onStart, onSuccess, onFailure } = useLoadingState<
+    Partial<Record<string, string>>
+  >({})
+
+  useEffect(() => {
+    onStart()
+  }, [onStart])
+
+  useEffect(() => {
+    async function fetchAddressesFromRegistry(): Promise<void> {
+      if (!masterRegistry) {
+        console.error(
+          "Master Registry not available. Unable to retrieve contract addresses",
+        )
+        return
+      }
+
+      try {
+        const addresses: Partial<Record<string, string>> = {}
+        if (chainId !== ChainId.MAINNET && chainId !== ChainId.HARDHAT) {
+          const childGaugeFactoryAddress =
+            await masterRegistry.resolveNameToLatestAddress(
+              CHILD_GAUGE_FACTORY_NAME,
+            )
+          addresses[parseBytes32String(CHILD_GAUGE_FACTORY_NAME)] =
+            childGaugeFactoryAddress
+          onSuccess(addresses)
+        }
+      } catch (error) {
+        const errorMessage =
+          "Unable to retrieve and set addresses from MasterRegistry"
+        console.error(errorMessage)
+        onFailure(error as Error)
+      }
+    }
+    void fetchAddressesFromRegistry()
+  }, [chainId, masterRegistry, onFailure, onSuccess])
+  return (
+    <RegistryAddressContext.Provider value={state}>
+      {children}
+    </RegistryAddressContext.Provider>
+  )
+}


### PR DESCRIPTION
***Description***: The Address Registry Provider is responsible for calling the MasterRegistry and resolve addresses that are used often. This is also the start of moving away from accessing contracts as hooks to instantiating `Contract` objects whenever they're needed.

The first contract address is `ChildGaugeFactory`. Only available on non-mainnet/hardhat chainIds.