### PR TITLE
revert input padding on textfieldtheme

### DIFF
--- a/src/theme/components/TextFieldTheme.ts
+++ b/src/theme/components/TextFieldTheme.ts
@@ -10,8 +10,8 @@ export default function TextFieldTheme(): Components {
         },
         input: {
           paddingLeft: 8,
-          paddingTop: 6.5,
-          paddingBottom: 6.5,
+          paddingTop: 14.5,
+          paddingBottom: 14.5,
         },
         inputSizeSmall: {
           paddingTop: 4.5,


### PR DESCRIPTION
change reverts the padding applied to text inputs by default. 