### PR TITLE
TokenClaimDialog rewards patch

### DIFF
--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -11,7 +11,7 @@ import {
 } from "@mui/material"
 import { BasicPool, BasicPoolsContext } from "../providers/BasicPoolsProvider"
 import { ChainId, SDL_TOKEN } from "../constants"
-import { GaugeReward, areGaugesActive } from "../utils/gauges"
+import { GaugeReward, GaugeUserReward, areGaugesActive } from "../utils/gauges"
 import React, {
   ReactElement,
   useCallback,
@@ -271,7 +271,12 @@ export default function TokenClaimDialog({
                           ["SDL", userClaimableSdl ?? Zero],
                           ...userClaimableOtherRewards,
                         ]}
-                        claimCallback={() => void claimGaugeReward(gauge)}
+                        claimCallback={() =>
+                          void claimGaugeReward(
+                            gauge,
+                            userState?.gaugeRewards || {},
+                          )
+                        }
                         status={
                           claimsStatuses["allGauges"] ||
                           claimsStatuses[gauge?.gaugeName ?? ""]
@@ -455,13 +460,16 @@ function useRewardClaims() {
         address: string
         rewards: GaugeReward[]
       } | null,
+      userGaugeRewards: Partial<{
+        [gaugeAddress: string]: GaugeUserReward
+      }>,
     ) => {
       if (!chainId || !account || !gaugeMinterContract || !library || !gauge) {
         enqueueToast("error", "Unable to claim reward")
         return
       }
 
-      if (gauge.rewards.length === 0) {
+      if (gauge.rewards.length === 0 && !Object.keys(userGaugeRewards).length) {
         enqueueToast("error", "No rewards to claim")
         return
       }

--- a/src/components/TokenClaimDialog.tsx
+++ b/src/components/TokenClaimDialog.tsx
@@ -469,7 +469,11 @@ function useRewardClaims() {
         return
       }
 
-      if (gauge.rewards.length === 0 && !Object.keys(userGaugeRewards).length) {
+      const doesUserHaveGaugeRewards = Boolean(
+        Object.keys(userGaugeRewards).length,
+      )
+
+      if (gauge.rewards.length === 0 && !doesUserHaveGaugeRewards) {
         enqueueToast("error", "No rewards to claim")
         return
       }
@@ -481,7 +485,7 @@ function useRewardClaims() {
         if (minterRewards.length > 0) {
           claimPromises.push(gaugeMinterContract.mint(gauge.address))
         }
-        if (gaugeRewards.length > 0) {
+        if (gaugeRewards.length > 0 || doesUserHaveGaugeRewards) {
           const liquidityGaugeContract = getContract(
             gauge.address,
             LIQUIDITY_GAUGE_V5_ABI,

--- a/src/utils/gauges.ts
+++ b/src/utils/gauges.ts
@@ -552,9 +552,7 @@ function buildLpTokenAddressToGauge(
       })
       .filter(Boolean) as GaugeReward[]
 
-    const combinedRewards = gaugeTokenReward.concat(
-      sdlRate.gt(Zero) ? [sdlReward] : [],
-    )
+    const combinedRewards = gaugeTokenReward.concat([sdlReward])
 
     const gauge: Gauge = {
       address: gaugeAddress,


### PR DESCRIPTION
***Description***: In the case of when a user has SDL/Minter rewards for a gauge that previously has a non-Zero SDL rate and currently has a Zero rate value, the sdlReward does not get added to the gauge rewards attribute due to the Zero SDL rate check.

***Solution***: Removed the sdlRate check when concating the rewards lists and allow ClaimTokenDialog to handle showing/hiding gauge rewards depending on rewards balance rather than sdlRate