### PR TITLE
Use '_write' fn for gauges data, update controller abi to view, format gauge names

### DIFF
--- a/src/constants/abis/gaugeController.json
+++ b/src/constants/abis/gaugeController.json
@@ -320,7 +320,7 @@
     ]
   },
   {
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function",
     "name": "gauge_relative_weight_write",
     "inputs": [

--- a/src/hooks/useSidechainGaugeWeightDataOnMainnet.ts
+++ b/src/hooks/useSidechainGaugeWeightDataOnMainnet.ts
@@ -28,6 +28,7 @@ type SidechainGauges = {
 type SidechainGauge = {
   chainId: ChainId
   gaugeName: string
+  displayName: string
   address: string
   isKilled: boolean
   gaugeRelativeWeight: BigNumber
@@ -49,7 +50,6 @@ export const useSidechainGaugeWeightDataOnMainnet =
       if (!IS_CROSS_CHAIN_GAUGES_LIVE) {
         return defaultSidechainGauges
       }
-
       const ethCallProvider = await getMulticallProvider(library, chainId)
       const gaugeControllerMultiCall = createMultiCallContract<GaugeController>(
         GAUGE_CONTROLLER_ADDRESSES[chainId],
@@ -82,7 +82,9 @@ export const useSidechainGaugeWeightDataOnMainnet =
             )
           }),
         )
-      ).map((addresses) => addresses.filter(Boolean) as string[])
+      )
+        .map((addresses) => addresses.filter(Boolean) as string[])
+        .map((addresses) => addresses.map((addr) => addr.toLowerCase()))
 
       const sidechainGaugesMultiCallContracts = sidechainGaugeAddresses.map(
         (gaugeAddresses) =>
@@ -113,8 +115,8 @@ export const useSidechainGaugeWeightDataOnMainnet =
             // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
             gaugeAddresses.map((gaugeAddress) => {
               // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-              return gaugeControllerMultiCall.gauge_relative_weight(
-                gaugeAddress.toLowerCase(),
+              return gaugeControllerMultiCall.gauge_relative_weight_write(
+                gaugeAddress,
               )
             }),
           ),
@@ -142,14 +144,19 @@ export const useSidechainGaugeWeightDataOnMainnet =
                   sidechainGaugesKilledStatuses[chainIdIndex][index] == null
                 )
                   return
-
+                const gaugeName =
+                  sidechainGaugesNames[chainIdIndex][index] || ""
+                const chainId = chainIds[chainIdIndex]
                 return {
-                  chainId: chainIds[chainIdIndex],
-                  gaugeName: sidechainGaugesNames[chainIdIndex][index],
+                  chainId,
+                  gaugeName,
                   address: gaugeAddresses[index],
                   gaugeRelativeWeight:
                     sidechainGaugesRelativeWeights[chainIdIndex][index],
                   isKilled: sidechainGaugesKilledStatuses[chainIdIndex][index],
+                  displayName: `${ChainId[chainId]}_${gaugeName
+                    .replace("Saddle ", "")
+                    .replace(" Root Gauge", "-gauge")}`,
                 }
               })
               .filter(Boolean) as SidechainGauge[],

--- a/src/utils/gauges.ts
+++ b/src/utils/gauges.ts
@@ -203,7 +203,7 @@ async function buildGaugeData(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       gaugeAddresses.map((gaugeAddress) =>
         // eslint-disable-next-line @typescript-eslint/no-unsafe-return, @typescript-eslint/no-unsafe-call
-        gaugeControllerMultiCall.gauge_relative_weight(gaugeAddress),
+        gaugeControllerMultiCall.gauge_relative_weight_write(gaugeAddress),
       ),
     )
 


### PR DESCRIPTION
Changes to support correct operation of sidechain gauges:
- Use '_write' fn when fetching gauges data
- Update controller abi to view
- Format gauge names to include chain name (for sidechains)
- Include sidechain root gauges in voting options

<img width="434" alt="Screen Shot 2022-12-19 at 6 15 10 PM" src="https://user-images.githubusercontent.com/7607886/208552362-6afda772-52eb-4114-a98f-f5aab4bc453e.png">
<img width="436" alt="Screen Shot 2022-12-19 at 6 15 04 PM" src="https://user-images.githubusercontent.com/7607886/208552365-380e3388-4fa0-451e-85ce-0b895c0c4be3.png">
