### PR TITLE
Redirect misnamed pools

### DIFF
--- a/src/hooks/useRedirectInvalidPool.ts
+++ b/src/hooks/useRedirectInvalidPool.ts
@@ -1,0 +1,18 @@
+import { useContext, useEffect } from "react"
+import { useHistory, useParams } from "react-router-dom"
+
+import { BasicPoolsContext } from "../providers/BasicPoolsProvider"
+
+export default function useRedirectInvalidPool() {
+  const { poolName } = useParams<{ poolName: string }>()
+  const basicPools = useContext(BasicPoolsContext)
+  const history = useHistory() as { replace: (path: string) => void }
+  useEffect(() => {
+    if (poolName && basicPools != null) {
+      if (!basicPools[poolName]) {
+        console.error(`Invalid pool name: ${poolName}`)
+        history.replace("/pools")
+      }
+    }
+  }, [basicPools, poolName, history])
+}

--- a/src/pages/Deposit.tsx
+++ b/src/pages/Deposit.tsx
@@ -33,10 +33,12 @@ import { useActiveWeb3React } from "../hooks"
 import { useApproveAndDeposit } from "../hooks/useApproveAndDeposit"
 import { useParams } from "react-router-dom"
 import { usePoolTokenBalances } from "../state/wallet/hooks"
+import useRedirectInvalidPool from "../hooks/useRedirectInvalidPool"
 import { useSelector } from "react-redux"
 import { useSwapContract } from "../hooks/useContract"
 
 function Deposit(): ReactElement | null {
+  useRedirectInvalidPool()
   const { poolName } = useParams<{ poolName: string }>()
   const basicPools = useContext(BasicPoolsContext)
   const basicTokens = useContext(TokensContext)

--- a/src/pages/Withdraw.tsx
+++ b/src/pages/Withdraw.tsx
@@ -22,11 +22,13 @@ import { useActiveWeb3React } from "../hooks"
 import { useApproveAndWithdraw } from "../hooks/useApproveAndWithdraw"
 import { useParams } from "react-router-dom"
 import usePoolData from "../hooks/usePoolData"
+import useRedirectInvalidPool from "../hooks/useRedirectInvalidPool"
 import { useSelector } from "react-redux"
 import { useSwapContract } from "../hooks/useContract"
 import useWithdrawFormState from "../hooks/useWithdrawFormState"
 
 function Withdraw(): ReactElement {
+  useRedirectInvalidPool()
   const { poolName } = useParams<{ poolName: string }>()
   const [poolData, userShareData] = usePoolData(poolName)
   const {


### PR DESCRIPTION
Automatically redirect abuses of the route wildcard in `/pools/:poolName/deposit` to `/pools`. Eg `pools/click_here/deposit` does not match a real pool name and will be redirected