### PR TITLE
Fix single token withdraws from metapools

### DIFF
--- a/src/hooks/useApproveAndWithdraw.ts
+++ b/src/hooks/useApproveAndWithdraw.ts
@@ -53,7 +53,7 @@ export function useApproveAndWithdraw(
         META_SWAP_ABI,
         library,
         account ?? undefined,
-      )
+      ) as MetaSwap
     }
   }, [chainId, library, account, pool?.poolAddress])
 
@@ -236,9 +236,7 @@ export function useApproveAndWithdraw(
         )
 
         if (!state.tokenFormState || !state.withdrawType) return
-        const lpTokenAmountToRemoveOneToken =
-          state.tokenFormState[state.withdrawType]?.valueSafe
-
+        const lpTokenAmountToRemoveOneToken = state.lpTokenAmountToSpend
         if (lpTokenAmountToRemoveOneToken) {
           spendTransaction =
             await effectiveSwapContract.removeLiquidityOneToken(

--- a/src/hooks/useWithdrawFormState.ts
+++ b/src/hooks/useWithdrawFormState.ts
@@ -217,6 +217,7 @@ export default function useWithdrawFormState(poolName: string) {
           }
         }
       } else {
+        // This case is the one-token case. Multiply the user's LP token balance by the % to remove
         try {
           if (state.percentage) {
             const tokenIndex = withdrawTokens.findIndex(
@@ -224,10 +225,9 @@ export default function useWithdrawFormState(poolName: string) {
             )
 
             let tokenAmount: BigNumber
-            const withdrawAmount = withdrawTokens[tokenIndex].value
+            const withdrawAmount = effectiveUserLPTokenBalance
               .mul(parseUnits(percentageRaw, 5)) // difference between numerator and denominator because we're going from 100 to 1.00
               .div(10 ** 7)
-
             if (poolData.isMetaSwap) {
               if (shouldWithdrawWrapped) {
                 tokenAmount = await (


### PR DESCRIPTION
This fixes two issues:
- the output of `calculateRemoveLiquidityOneToken` was being used as an input instead of an LP Token amount
- `calculateTokenAmount` was being called on a MetaSwapDeposit contract even when the user was withdrawing wrapped, but it should have been on the MetaSwap contract instead