### PR TITLE
multi-reward gauge improvements

### DIFF
--- a/src/components/GaugeRewardsDisplay.tsx
+++ b/src/components/GaugeRewardsDisplay.tsx
@@ -14,7 +14,7 @@ export default function GaugeRewardsDisplay({
     <>
       {gaugeAprs.map((aprData) => {
         if (!aprData.rewardToken) return null
-        const { symbol, address } = aprData.rewardToken
+        const { symbol, address, decimals } = aprData.rewardToken
         if (aprData.amountPerDay) {
           const { min, max } = aprData.amountPerDay
           if (max.isZero()) return null
@@ -24,8 +24,8 @@ export default function GaugeRewardsDisplay({
                 {symbol}/24h:
               </Typography>
               <Typography component="span" variant="subtitle1">
-                {`${commify(formatBNToString(min, 18, 0))}-${commify(
-                  formatBNToString(max, 18, 0),
+                {`${commify(formatBNToString(min, decimals, 0))}-${commify(
+                  formatBNToString(max, decimals, 0),
                 )}`}
               </Typography>
             </Box>
@@ -41,9 +41,9 @@ export default function GaugeRewardsDisplay({
               <Typography component="span">
                 {`${formatBNToPercentString(
                   min,
-                  18,
+                  decimals,
                   2,
-                )}-${formatBNToPercentString(max, 18, 2)}`}
+                )}-${formatBNToPercentString(max, decimals, 2)}`}
               </Typography>
             </Box>
           )

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -765,6 +765,18 @@ export const SUSD_SWAP_V2_V3_TOKEN = new Token(
   true,
 )
 
+export const FUSDC_TOKEN = new Token(
+  buildAddresses({
+    [ChainId.ARBITRUM]: "0x4cfa50b7ce747e2d61724fcac57f24b748ff2b2a",
+  }),
+  6,
+  "fUSDC",
+  "fluid-usdc",
+  "Fluid USDC",
+  false,
+  false,
+)
+
 export const BTC_SWAP_TOKEN = new Token(
   BTC_SWAP_TOKEN_CONTRACT_ADDRESSES,
   18,

--- a/src/utils/updateTokenPrices.ts
+++ b/src/utils/updateTokenPrices.ts
@@ -3,7 +3,13 @@ import {
   COINGECKO_PLATFORM_ID,
   SUPPORTED_NETWORKS,
 } from "../constants/networks"
-import { PoolTypes, SDL_TOKEN, SPA, TOKENS_MAP } from "../constants"
+import {
+  FUSDC_TOKEN,
+  PoolTypes,
+  SDL_TOKEN,
+  SPA,
+  TOKENS_MAP,
+} from "../constants"
 import { TokenPricesUSD, updateTokensPricesUSD } from "../state/application"
 
 import { AppDispatch } from "../state"
@@ -37,6 +43,7 @@ const otherTokens = {
   T: "threshold-network-token",
   [SDL_TOKEN.symbol]: SDL_TOKEN.geckoId,
   [SPA.symbol]: SPA.geckoId,
+  [FUSDC_TOKEN.symbol]: FUSDC_TOKEN.geckoId,
 }
 
 export function oldFetchTokenPricesUSD(


### PR DESCRIPTION
- handle display of reward that don't use 18 decimals
- merge rewards in the same token (eg SDL from both gauge and minter). Do this both in apr calculation, display, and claiming
- 
<img width="150" alt="Screen Shot 2023-04-13 at 1 19 13 AM" src="https://user-images.githubusercontent.com/7607886/231670723-d396ca69-6a44-4ea4-aa8e-8de436599fb2.png">
